### PR TITLE
[Fix] Preflight 요청 허용

### DIFF
--- a/src/main/java/shympyo/auth/config/SecurityConfig.java
+++ b/src/main/java/shympyo/auth/config/SecurityConfig.java
@@ -28,11 +28,12 @@ public class SecurityConfig {
 
     @Bean
     public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
-        http.cors(cors -> {})
+        http
+                .cors(cors -> {})
                 .csrf(csrf -> csrf.disable())
-                .sessionManagement(s -> s.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
                 .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
                 .authorizeHttpRequests(auth -> auth
+                        .requestMatchers(org.springframework.http.HttpMethod.OPTIONS, "/**").permitAll()
                         .requestMatchers(
                                 "/", "/error",
 

--- a/src/main/java/shympyo/auth/config/SecurityConfig.java
+++ b/src/main/java/shympyo/auth/config/SecurityConfig.java
@@ -30,6 +30,7 @@ public class SecurityConfig {
     public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
         http.cors(cors -> {})
                 .csrf(csrf -> csrf.disable())
+                .sessionManagement(s -> s.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
                 .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
                 .authorizeHttpRequests(auth -> auth
                         .requestMatchers(


### PR DESCRIPTION


## ✅ PR 내용

### ✨ 어떤 작업을 했나요?
> 작업한 내용을 간단히 요약해주세요.

- preflight 요청을 허용해야 하더라구요

---

### 🔗 관련 이슈
> 이 PR이 병합되면 자동으로 닫힐 이슈 번호를 적어주세요.  
> `closes #이슈번호`, `fixes #이슈번호`, `resolves #이슈번호` 형식으로 작성해야 자동 닫기가 됩니다.

closes #22 

---

### 🧪 테스트 방법
> PR을 테스트한 방법이나 확인 결과를 적어주세요.

- [ ] 직접 테스트 완료
- [ ] Postman / Swagger로 API 확인
- [ ] 테스트 코드 통과

---

### 💬 기타 공유할 내용
> 리뷰어에게 공유할 내용이나 참고해야 할 사항이 있다면 자유롭게 작성해주세요.

🔎 Preflight란?

브라우저가 실제 요청을 보내기 전에, 먼저 서버한테 물어보는 확인용 요청

HTTP OPTIONS 메서드를 사용한다.

목적: “내가 이 도메인에서 이런 메서드·헤더로 요청해도 돼?” 하고 서버 허락을 확인하는 것

🔎 언제 발생하나?

브라우저의 CORS 정책에서 “Simple Request” 조건을 만족하지 않을 때 프리플라이트를 보낸다.

Simple Request 조건

메서드가 GET, HEAD, POST 중 하나여야 함

POST라면 Content-Type이 application/x-www-form-urlencoded, multipart/form-data, text/plain 중 하나여야 함

커스텀 헤더(예: Authorization, X-Requested-With)가 없어야 함

➡️ 이 조건을 벗어나면 → 브라우저가 OPTIONS 프리플라이트 요청을 자동으로 먼저 보냄