### PR TITLE
[Refactor] 사용자 제공 쉼터 맵 서비스에 추가  

### DIFF
--- a/src/main/java/shympyo/map/controller/MapController.java
+++ b/src/main/java/shympyo/map/controller/MapController.java
@@ -23,42 +23,41 @@ public class MapController {
 
     private final MapService mapService;
 
-    @Operation(
-            summary = "주변 장소 지도 조회",
-            description = "위도(lat), 경도(lon) 좌표를 기준으로 반경 내 장소를 지도 형태로 조회한다."
-    )
+    @Operation(summary = "주변 장소 지도 조회")
     @GetMapping("/nearby")
     public ResponseEntity<CommonResponse<List<NearbyMapResponse>>> nearby(
-            @Parameter(description = "위도", example = "37.5665") @RequestParam double lat,
-            @Parameter(description = "경도", example = "126.9780") @RequestParam double lon,
-            @Parameter(description = "검색 반경 (미터)", example = "200") @RequestParam(defaultValue = "100") int radius,
-            @Parameter(description = "조회 최대 개수", example = "50") @RequestParam(defaultValue = "100") int limit
+            @RequestParam double lat,
+            @RequestParam double lon,
+            @RequestParam(defaultValue = "100") int radius,
+            @RequestParam(defaultValue = "100") int limit
     ) {
         return ResponseUtil.success(mapService.findNearby(lat, lon, radius, limit));
     }
 
-    @Operation(
-            summary = "주변 장소 목록 조회",
-            description = "위도(lat), 경도(lon) 좌표를 기준으로 반경 내 장소를 리스트 형태로 조회한다."
-    )
+    @Operation(summary = "주변 장소 목록 조회")
     @GetMapping("/nearby-list")
     public ResponseEntity<CommonResponse<List<NearbyListResponse>>> nearbyList(
-            @Parameter(description = "위도", example = "37.5665") @RequestParam double lat,
-            @Parameter(description = "경도", example = "126.9780") @RequestParam double lon,
-            @Parameter(description = "검색 반경 (미터)", example = "200") @RequestParam(defaultValue = "100") int radius,
-            @Parameter(description = "조회 최대 개수", example = "20") @RequestParam(defaultValue = "50") int limit
+            @RequestParam double lat,
+            @RequestParam double lon,
+            @RequestParam(defaultValue = "100") int radius,
+            @RequestParam(defaultValue = "50") int limit
     ) {
         return ResponseUtil.success(mapService.findNearbyList(lat, lon, radius, limit));
     }
 
-    @Operation(
-            summary = "장소 상세 조회",
-            description = "장소 ID를 사용해 상세 정보를 조회한다."
-    )
-    @GetMapping("/{id}")
-    public ResponseEntity<CommonResponse<PlaceDetailResponse>> place(
-            @Parameter(description = "장소 ID", example = "123") @PathVariable Long id
+    @Operation(summary = "공공 쉼터 상세 조회")
+    @GetMapping("/public/{id}")
+    public ResponseEntity<CommonResponse<PlaceDetailResponse>> getMap(
+            @PathVariable Long id
     ) {
-        return ResponseUtil.success(mapService.findPlace(id));
+        return ResponseUtil.success(mapService.getMap(id));
+    }
+
+    @Operation(summary = "사용자 제공 쉼터 상세 조회")
+    @GetMapping("/user/{id}")
+    public ResponseEntity<CommonResponse<PlaceDetailResponse>> getPlace(
+            @PathVariable Long id
+    ) {
+        return ResponseUtil.success(mapService.getPlace(id));
     }
 }

--- a/src/main/java/shympyo/map/controller/MapController.java
+++ b/src/main/java/shympyo/map/controller/MapController.java
@@ -2,12 +2,14 @@ package shympyo.map.controller;
 
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.ArraySchema;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 import shympyo.global.response.CommonResponse;
 import shympyo.global.response.ResponseUtil;
+import shympyo.map.domain.PlaceType;
 import shympyo.map.dto.NearbyListResponse;
 import shympyo.map.dto.NearbyMapResponse;
 import shympyo.map.dto.PlaceDetailResponse;
@@ -23,37 +25,101 @@ public class MapController {
 
     private final MapService mapService;
 
-    @Operation(summary = "주변 장소 지도 조회")
+    @Operation(
+            summary = "주변 장소 지도 조회",
+            description = """
+    위도(lat), 경도(lon) 좌표를 기준으로 반경 내 장소를 지도용으로 조회한다.  
+
+    - `radius` : 검색 반경 (미터), 최소 1m ~ 최대 5km  
+    - `limit` : 조회 최대 개수, 최대 200  
+    - `types` : 조회할 장소 타입 필터 (예: CULTURE, SHELTER, USER_SHELTER 등).  
+      - 여러 개 지정 가능 → `types=CULTURE&types=SHELTER`  
+      - 쉼표 구분도 가능 → `types=CULTURE,SHELTER`  
+      - 비워두면 모든 타입 조회
+    """
+    )
     @GetMapping("/nearby")
     public ResponseEntity<CommonResponse<List<NearbyMapResponse>>> nearby(
+            @Parameter(description = "위도", example = "37.5665")
             @RequestParam double lat,
+
+            @Parameter(description = "경도", example = "126.9780")
             @RequestParam double lon,
+
+            @Parameter(description = "검색 반경 (m)", example = "200")
             @RequestParam(defaultValue = "100") int radius,
-            @RequestParam(defaultValue = "100") int limit
+
+            @Parameter(description = "조회 최대 개수", example = "50")
+            @RequestParam(defaultValue = "100") int limit,
+
+            @Parameter(
+                    description = "조회할 타입 목록. 예: types=CULTURE,SHELTER or types=CULTURE&types=SHELTER",
+                    array = @io.swagger.v3.oas.annotations.media.ArraySchema(
+                            schema = @io.swagger.v3.oas.annotations.media.Schema(implementation = shympyo.map.domain.PlaceType.class)
+                    )
+            )
+            @RequestParam(name = "types", required = false) List<PlaceType> types
     ) {
-        return ResponseUtil.success(mapService.findNearby(lat, lon, radius, limit));
+        return ResponseUtil.success(mapService.findNearby(lat, lon, radius, limit, types));
     }
 
-    @Operation(summary = "주변 장소 목록 조회")
+
+
+    @Operation(
+            summary = "주변 장소 목록 조회",
+            description = """
+    위도(lat), 경도(lon) 좌표를 기준으로 반경 내 장소를 리스트 형태로 조회한다.  
+
+    - `radius` : 검색 반경 (미터), 최소 1m ~ 최대 5km  
+    - `limit` : 조회 최대 개수, 최대 200  
+    - `types` : 조회할 장소 타입 필터 (예: CULTURE, SHELTER, USER_SHELTER 등).  
+      - 여러 개 지정 가능 → `types=CULTURE&types=SHELTER`  
+      - 쉼표 구분도 가능 → `types=CULTURE,SHELTER`  
+      - 비워두면 모든 타입 조회
+    """
+    )
     @GetMapping("/nearby-list")
     public ResponseEntity<CommonResponse<List<NearbyListResponse>>> nearbyList(
+            @Parameter(description = "위도", example = "37.5665")
             @RequestParam double lat,
+
+            @Parameter(description = "경도", example = "126.9780")
             @RequestParam double lon,
+
+            @Parameter(description = "검색 반경 (m)", example = "200")
             @RequestParam(defaultValue = "100") int radius,
-            @RequestParam(defaultValue = "50") int limit
+
+            @Parameter(description = "조회 최대 개수", example = "50")
+            @RequestParam(defaultValue = "50") int limit,
+
+            @Parameter(
+                    description = "조회할 타입 목록. 여러 개 가능 (예: CULTURE,SHELTER)",
+                    array = @ArraySchema(
+                            schema = @io.swagger.v3.oas.annotations.media.Schema(implementation = shympyo.map.domain.PlaceType.class)
+                    )
+            )
+            @RequestParam(name = "types", required = false) List<PlaceType> types
     ) {
-        return ResponseUtil.success(mapService.findNearbyList(lat, lon, radius, limit));
+        return ResponseUtil.success(mapService.findNearbyList(lat, lon, radius, limit, types));
     }
 
-    @Operation(summary = "공공 쉼터 상세 조회")
+
+    @Operation(
+            summary = "공공 쉼터 상세 조회",
+            description = "공공 데이터(Map)에 등록된 쉼터의 상세 정보를 조회한다."
+    )
     @GetMapping("/public/{id}")
     public ResponseEntity<CommonResponse<PlaceDetailResponse>> getMap(
+            @Parameter(description = "공공 쉼터 ID", example = "123")
             @PathVariable Long id
     ) {
         return ResponseUtil.success(mapService.getMap(id));
     }
 
-    @Operation(summary = "사용자 제공 쉼터 상세 조회")
+    @Operation(
+            summary = "사용자 제공 쉼터 상세 조회",
+            description = "민간 데이터(Place)에 등록된 쉼터의 상세 정보를 조회한다."
+    )
     @GetMapping("/user/{id}")
     public ResponseEntity<CommonResponse<PlaceDetailResponse>> getPlace(
             @PathVariable Long id

--- a/src/main/java/shympyo/map/domain/PlaceType.java
+++ b/src/main/java/shympyo/map/domain/PlaceType.java
@@ -4,5 +4,6 @@ public enum PlaceType {
     CULTURE,
     SHELTER,
     STATION,
-    CLIMATE_SHELTER
+    CLIMATE_SHELTER,
+    USER_SHELTER
 }

--- a/src/main/java/shympyo/map/repository/MapRepository.java
+++ b/src/main/java/shympyo/map/repository/MapRepository.java
@@ -6,6 +6,7 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 import shympyo.map.domain.Map;
+import shympyo.map.domain.PlaceType;
 
 import java.util.List;
 
@@ -32,9 +33,9 @@ public interface MapRepository extends JpaRepository<Map, Long> {
           AND m.longitude BETWEEN :minLon AND :maxLon
           AND m.type IN :types
     """)
-    List<shympyo.map.domain.Map> findInBoundingBox(
+    List<Map> findInBoundingBox(
             double minLat, double maxLat,
             double minLon, double maxLon,
-            List<shympyo.map.domain.PlaceType> types
+            List<PlaceType> types
     );
 }

--- a/src/main/java/shympyo/map/repository/MapRepository.java
+++ b/src/main/java/shympyo/map/repository/MapRepository.java
@@ -25,4 +25,16 @@ public interface MapRepository extends JpaRepository<Map, Long> {
             @Param("maxLon") double maxLon
     );
 
+    @Query("""
+        SELECT m
+        FROM Map m
+        WHERE m.latitude  BETWEEN :minLat AND :maxLat
+          AND m.longitude BETWEEN :minLon AND :maxLon
+          AND m.type IN :types
+    """)
+    List<shympyo.map.domain.Map> findInBoundingBox(
+            double minLat, double maxLat,
+            double minLon, double maxLon,
+            List<shympyo.map.domain.PlaceType> types
+    );
 }

--- a/src/main/java/shympyo/map/service/MapService.java
+++ b/src/main/java/shympyo/map/service/MapService.java
@@ -3,12 +3,16 @@ package shympyo.map.service;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import shympyo.map.domain.Map;
+import shympyo.map.domain.PlaceType;
 import shympyo.map.dto.NearbyListResponse;
 import shympyo.map.dto.NearbyMapResponse;
 import shympyo.map.dto.PlaceDetailResponse;
 import shympyo.map.repository.MapRepository;
+import shympyo.rental.repository.PlaceRepository;
 
+import java.util.Collection;
 import java.util.Comparator;
+import java.util.EnumSet;
 import java.util.List;
 
 @Service
@@ -16,30 +20,44 @@ import java.util.List;
 public class MapService {
 
     private final MapRepository mapRepository;
-    private static final double EARTH_R = 6371000.0; // 지구 반지름(m)
+    private final PlaceRepository placeRepository;
 
+    private static final double EARTH_R = 6371000.0;
 
-    // 조회하기
-    // 현재 좌표를 기준으로 반경 몇 미터 안에 장소를 반환
+    private static final List<PlaceType> DEFAULT_TYPES = List.copyOf(EnumSet.allOf(PlaceType.class));
+
+    private static class BoundingBox {
+        final double minLat;
+        final double maxLat;
+        final double minLon;
+        final double maxLon;
+
+        BoundingBox(double minLat, double maxLat, double minLon, double maxLon) {
+            this.minLat = minLat;
+            this.maxLat = maxLat;
+            this.minLon = minLon;
+            this.maxLon = maxLon;
+        }
+    }
+
     public List<NearbyMapResponse> findNearby(double lat, double lon, int radiusMeters, int limit) {
-        // 1) 파라미터 가드
+        return findNearby(lat, lon, radiusMeters, limit, DEFAULT_TYPES);
+    }
+
+    public List<NearbyMapResponse> findNearby(double lat, double lon, int radiusMeters, int limit, Collection<PlaceType> includeTypes){
+
         final int radius   = Math.max(1, Math.min(radiusMeters, 5_000)); // 1m ~ 5km
         final int maxLimit = Math.max(1, Math.min(limit, 200));
 
-        // 2) 바운딩 박스(deg)
-        final double latDeg = radius / 111_320.0; // 위도 1도 ≈ 111.32km
-        double cosLat = Math.cos(Math.toRadians(lat));
-        if (Math.abs(cosLat) < 1e-12) cosLat = 1e-12; // 극지방 분모 0 방지
-        final double lonDeg = radius / (111_320.0 * cosLat);
+        BoundingBox box = calculateBoundingBox(lat, lon, radius);
 
-        final double minLat = lat - latDeg, maxLat = lat + latDeg;
-        final double minLon = lon - lonDeg, maxLon = lon + lonDeg;
+        var types = (includeTypes == null || includeTypes.isEmpty())
+                ? DEFAULT_TYPES
+                : List.copyOf(includeTypes);
 
-        // 3) 후보 조회 (인덱스 권장: CREATE INDEX IF NOT EXISTS map_lat_lon_idx ON map(latitude, longitude))
         List<shympyo.map.domain.Map> candidates =
-                mapRepository.findInBoundingBox(minLat, maxLat, minLon, maxLon);
+                mapRepository.findInBoundingBox(box.minLat, box.maxLat, box.minLon, box.maxLon, includeTypes);
 
-        // 4) 거리 계산(중간 보관) → 반경 필터 → 거리 오름차순 정렬 → DTO로 투영 → 제한
         record Cand(shympyo.map.domain.Map m, double dist) {}
 
         return candidates.stream()
@@ -60,24 +78,21 @@ public class MapService {
     }
 
     public List<NearbyListResponse> findNearbyList(double lat, double lon, int radiusMeters, int limit) {
-        // 파라미터 가드
-        final int radius   = Math.max(1, Math.min(radiusMeters, 5_000)); // 1m ~ 5km
+
+        final int radius   = Math.max(1, Math.min(radiusMeters, 5_000));
         final int maxLimit = Math.max(1, Math.min(limit, 200));
 
-        // 바운딩 박스(degree)
-        final double latDeg = radius / 111_320.0; // 위도 1도 ≈ 111.32km
+        final double latDeg = radius / 111_320.0;
         double cosLat = Math.cos(Math.toRadians(lat));
-        if (Math.abs(cosLat) < 1e-12) cosLat = 1e-12; // 극지방 분모 0 방지
+        if (Math.abs(cosLat) < 1e-12) cosLat = 1e-12;
         final double lonDeg = radius / (111_320.0 * cosLat);
 
         final double minLat = lat - latDeg, maxLat = lat + latDeg;
         final double minLon = lon - lonDeg, maxLon = lon + lonDeg;
 
-        // 후보 조회 (인덱스 권장: CREATE INDEX IF NOT EXISTS map_lat_lon_idx ON map(latitude, longitude))
         List<shympyo.map.domain.Map> candidates =
                 mapRepository.findInBoundingBox(minLat, maxLat, minLon, maxLon);
 
-        // 거리 계산 → 반경 필터 → 거리 정렬 → DTO 매핑 → 제한
         record Cand(shympyo.map.domain.Map m, double dist) {}
 
         return candidates.stream()
@@ -114,7 +129,6 @@ public class MapService {
                 .build();
     }
 
-    // 하버사인 공식
     private static double haversine(double lat1, double lon1, double lat2, double lon2) {
         double dLat = Math.toRadians(lat2 - lat1);
         double dLon = Math.toRadians(lon2 - lon1);
@@ -122,5 +136,19 @@ public class MapService {
                 Math.cos(Math.toRadians(lat1)) * Math.cos(Math.toRadians(lat2)) *
                         Math.pow(Math.sin(dLon / 2), 2);
         return 2 * EARTH_R * Math.asin(Math.sqrt(a));
+    }
+
+    private BoundingBox calculateBoundingBox(double lat, double lon, int radiusMeters) {
+        final int radius = Math.max(1, Math.min(radiusMeters, 5_000)); // 1m ~ 5km
+
+        final double latDeg = radius / 111_320.0; // 위도 1도 ≈ 111.32km
+        double cosLat = Math.cos(Math.toRadians(lat));
+        if (Math.abs(cosLat) < 1e-12) cosLat = 1e-12; // 극지방 분모 0 방지
+        final double lonDeg = radius / (111_320.0 * cosLat);
+
+        return new BoundingBox(
+                lat - latDeg, lat + latDeg,
+                lon - lonDeg, lon + lonDeg
+        );
     }
 }

--- a/src/main/java/shympyo/map/service/MapService.java
+++ b/src/main/java/shympyo/map/service/MapService.java
@@ -8,12 +8,14 @@ import shympyo.map.dto.NearbyListResponse;
 import shympyo.map.dto.NearbyMapResponse;
 import shympyo.map.dto.PlaceDetailResponse;
 import shympyo.map.repository.MapRepository;
+import shympyo.rental.domain.Place;
 import shympyo.rental.repository.PlaceRepository;
 
-import java.util.Collection;
 import java.util.Comparator;
 import java.util.EnumSet;
 import java.util.List;
+
+import static java.util.stream.Stream.concat;
 
 @Service
 @RequiredArgsConstructor
@@ -44,79 +46,141 @@ public class MapService {
         return findNearby(lat, lon, radiusMeters, limit, DEFAULT_TYPES);
     }
 
-    public List<NearbyMapResponse> findNearby(double lat, double lon, int radiusMeters, int limit, Collection<PlaceType> includeTypes){
+    public List<NearbyMapResponse> findNearby(double lat, double lon, int radiusMeters, int limit, List<PlaceType> includeTypes){
 
         final int radius   = Math.max(1, Math.min(radiusMeters, 5_000)); // 1m ~ 5km
         final int maxLimit = Math.max(1, Math.min(limit, 200));
 
         BoundingBox box = calculateBoundingBox(lat, lon, radius);
 
-        var types = (includeTypes == null || includeTypes.isEmpty())
+        final List<PlaceType> types = (includeTypes == null || includeTypes.isEmpty())
                 ? DEFAULT_TYPES
                 : List.copyOf(includeTypes);
 
-        List<shympyo.map.domain.Map> candidates =
-                mapRepository.findInBoundingBox(box.minLat, box.maxLat, box.minLon, box.maxLon, includeTypes);
+        boolean includeProvided = types.contains(PlaceType.USER_SHELTER);
 
-        record Cand(shympyo.map.domain.Map m, double dist) {}
 
-        return candidates.stream()
-                .map(m -> new Cand(m, haversine(lat, lon, m.getLatitude(), m.getLongitude())))
-                .filter(c -> c.dist() <= radius)
-                .sorted(Comparator.comparingDouble(Cand::dist))
+        List<Map> maps = (includeTypes == null || includeTypes.isEmpty())
+                ? mapRepository.findInBoundingBox(box.minLat, box.maxLat, box.minLon, box.maxLon)
+                : mapRepository.findInBoundingBox(box.minLat, box.maxLat, box.minLon, box.maxLon, types);
+
+
+        List<Place> places = includeProvided
+                ? placeRepository.findInBoundingBox(box.minLat, box.maxLat, box.minLon, box.maxLon)
+                : List.of();
+
+
+        record Cand(long id, double lat_, double lon_, PlaceType type, double dist) {}
+
+        var mapCands = maps.stream()
+                .map(m -> new Cand(
+                        m.getId(),
+                        m.getLatitude(),
+                        m.getLongitude(),
+                        m.getType(),
+                        haversine(lat, lon, m.getLatitude(), m.getLongitude())
+                ));
+
+        var placeCands = places.stream()
+                .map(p -> new Cand(
+                        p.getId(),
+                        p.getLatitude(),
+                        p.getLongitude(),
+                        PlaceType.USER_SHELTER,
+                        haversine(lat, lon, p.getLatitude(), p.getLongitude())
+                ));
+
+        return concat(mapCands, placeCands)
+                .filter(c -> c.dist <= radius)
+                .sorted(Comparator.comparingDouble(c -> c.dist))
                 .limit(maxLimit)
-                .map(c -> {
-                    var m = c.m();
-                    return new NearbyMapResponse(
-                            m.getId(),
-                            m.getLatitude(),
-                            m.getLongitude(),
-                            m.getType()
-                    );
-                })
+                .map(c -> new NearbyMapResponse(
+                        c.id,
+                        c.lat_,
+                        c.lon_,
+                        c.type
+                ))
                 .toList();
     }
 
     public List<NearbyListResponse> findNearbyList(double lat, double lon, int radiusMeters, int limit) {
+        return findNearbyList(lat, lon, radiusMeters, limit, DEFAULT_TYPES);
+    }
+
+
+    public List<NearbyListResponse> findNearbyList(double lat, double lon, int radiusMeters, int limit, List<PlaceType> includeTypes) {
 
         final int radius   = Math.max(1, Math.min(radiusMeters, 5_000));
         final int maxLimit = Math.max(1, Math.min(limit, 200));
 
-        final double latDeg = radius / 111_320.0;
-        double cosLat = Math.cos(Math.toRadians(lat));
-        if (Math.abs(cosLat) < 1e-12) cosLat = 1e-12;
-        final double lonDeg = radius / (111_320.0 * cosLat);
+        BoundingBox box = calculateBoundingBox(lat, lon, radius);
 
-        final double minLat = lat - latDeg, maxLat = lat + latDeg;
-        final double minLon = lon - lonDeg, maxLon = lon + lonDeg;
+        final List<PlaceType> types = (includeTypes == null || includeTypes.isEmpty())
+                ? DEFAULT_TYPES
+                : List.copyOf(includeTypes);
 
-        List<shympyo.map.domain.Map> candidates =
-                mapRepository.findInBoundingBox(minLat, maxLat, minLon, maxLon);
-
-        record Cand(shympyo.map.domain.Map m, double dist) {}
-
-        return candidates.stream()
-                .map(m -> new Cand(m, haversine(lat, lon, m.getLatitude(), m.getLongitude())))
-                .filter(c -> c.dist() <= radius)
-                .sorted(Comparator.comparingDouble(Cand::dist))
-                .limit(maxLimit)
-                .map(c -> {
-                    var m = c.m();
-                    return new NearbyListResponse(
-                            m.getId(),
-                            m.getName(),
-                            m.getAddress(),
-                            m.getContent(),    // LOB이면 길 수 있음
-                            m.getType(),
-                            c.dist()
-                    );
-                })
+        final List<PlaceType> mapOnlyTypes = types.stream()
+                .filter(t -> t != PlaceType.USER_SHELTER)
                 .toList();
+
+        final List<Map> maps = mapOnlyTypes.isEmpty()
+                ? mapRepository.findInBoundingBox(box.minLat, box.maxLat, box.minLon, box.maxLon)
+                : mapRepository.findInBoundingBox(box.minLat, box.maxLat, box.minLon, box.maxLon, mapOnlyTypes);
+
+        final boolean includeProvided = types.contains(PlaceType.USER_SHELTER);
+
+        final List<Place> places = includeProvided
+                ? placeRepository.findInBoundingBox(box.minLat, box.maxLat, box.minLon, box.maxLon)
+                : List.of();
+
+        record Cand(
+                long id,
+                String name,
+                String address,
+                String content,
+                PlaceType type,
+                double dist
+        ) {}
+
+        var mapCands = maps.stream()
+                .map(m -> new Cand(
+                        m.getId(),
+                        m.getName(),
+                        m.getAddress(),
+                        m.getContent(),
+                        m.getType(),
+                        haversine(lat, lon, m.getLatitude(), m.getLongitude())
+                ));
+
+        var placeCands = places.stream()
+                .map(p -> new Cand(
+                        p.getId(),
+                        p.getName(),
+                        p.getAddress(),
+                        p.getContent(),
+                        PlaceType.USER_SHELTER,
+                        haversine(lat, lon, p.getLatitude(), p.getLongitude())
+                ));
+
+        return concat(mapCands, placeCands)
+                .filter(c -> c.dist <= radius)
+                .sorted(Comparator.comparingDouble(c -> c.dist))
+                .limit(maxLimit)
+                .map(c -> new NearbyListResponse(
+                        c.id,
+                        c.name,
+                        c.address,
+                        c.content,
+                        c.type,
+                        c.dist
+                ))
+                .toList();
+
     }
 
-    public PlaceDetailResponse findPlace(Long placeId){
+    public PlaceDetailResponse getMap(Long mapId){
 
-        Map map = mapRepository.findById(placeId)
+        Map map = mapRepository.findById(mapId)
                 .orElseThrow(()-> new IllegalArgumentException("해당 장소가 없습니다."));
 
         return PlaceDetailResponse.builder()
@@ -127,6 +191,23 @@ public class MapService {
                 .address(map.getAddress())
                 .latitude(map.getLatitude())
                 .build();
+
+    }
+
+    public PlaceDetailResponse getPlace(Long placeId){
+
+        Place place = placeRepository.findById(placeId)
+                .orElseThrow(()-> new IllegalArgumentException("해당 장소가 없습니다."));
+
+        return PlaceDetailResponse.builder()
+                .id(place.getId())
+                .name(place.getName())
+                .type(PlaceType.USER_SHELTER)
+                .longitude(place.getLongitude())
+                .address(place.getAddress())
+                .latitude(place.getLatitude())
+                .build();
+
     }
 
     private static double haversine(double lat1, double lon1, double lat2, double lon2) {
@@ -139,11 +220,12 @@ public class MapService {
     }
 
     private BoundingBox calculateBoundingBox(double lat, double lon, int radiusMeters) {
-        final int radius = Math.max(1, Math.min(radiusMeters, 5_000)); // 1m ~ 5km
 
-        final double latDeg = radius / 111_320.0; // 위도 1도 ≈ 111.32km
+        final int radius = Math.max(1, Math.min(radiusMeters, 5_000));
+
+        final double latDeg = radius / 111_320.0;
         double cosLat = Math.cos(Math.toRadians(lat));
-        if (Math.abs(cosLat) < 1e-12) cosLat = 1e-12; // 극지방 분모 0 방지
+        if (Math.abs(cosLat) < 1e-12) cosLat = 1e-12;
         final double lonDeg = radius / (111_320.0 * cosLat);
 
         return new BoundingBox(

--- a/src/main/java/shympyo/rental/repository/PlaceRepository.java
+++ b/src/main/java/shympyo/rental/repository/PlaceRepository.java
@@ -20,15 +20,18 @@ public interface PlaceRepository extends JpaRepository<Place, Long> {
 
     Optional<Place> findByOwnerId(Long ownerId);
 
+
     @Query("""
-        SELECT m
-        FROM Map m
-        WHERE m.latitude  BETWEEN :minLat AND :maxLat
-          AND m.longitude BETWEEN :minLon AND :maxLon
+        SELECT p
+        FROM Place p
+        WHERE p.latitude  BETWEEN :minLat AND :maxLat
+          AND p.longitude BETWEEN :minLon AND :maxLon
     """)
     List<Place> findInBoundingBox(
-            double minLat, double maxLat,
-            double minLon, double maxLon
+            @Param("minLat") double minLat,
+            @Param("maxLat") double maxLat,
+            @Param("minLon") double minLon,
+            @Param("maxLon") double maxLon
     );
 
     boolean existsByCode(String code);

--- a/src/main/java/shympyo/rental/repository/PlaceRepository.java
+++ b/src/main/java/shympyo/rental/repository/PlaceRepository.java
@@ -20,5 +20,18 @@ public interface PlaceRepository extends JpaRepository<Place, Long> {
 
     Optional<Place> findByOwnerId(Long ownerId);
 
+    @Query("""
+        SELECT m
+        FROM Map m
+        WHERE m.latitude  BETWEEN :minLat AND :maxLat
+          AND m.longitude BETWEEN :minLon AND :maxLon
+    """)
+    List<Place> findInBoundingBox(
+            double minLat, double maxLat,
+            double minLon, double maxLon
+    );
+
     boolean existsByCode(String code);
+
+
 }


### PR DESCRIPTION
## ✅ PR 내용

### ✨ 어떤 작업을 했나요?
> 작업한 내용을 간단히 요약해주세요.

- 기존에는 공공 쉼터만 지도 위에 보여줬었는데 이제는 사용자가 제공한 쉼터도 보여줍니다.
- 쿼리파라미터로 특정 타입을 지정해서 조회할 수 있습니다.
- 사용자 제공 쉼터는 DB 테이블이 공공 쉼터랑 다르기 때문에 사용자 제공 쉼터 전용 상세 보기 추가했습니다.
- 그에 따라 기존 url도 변경되었습니다 : /api/map/{id} -> /api/map/public/{id} + /api/map/user/{id}

---

### 🔗 관련 이슈
> 이 PR이 병합되면 자동으로 닫힐 이슈 번호를 적어주세요.  
> `closes #이슈번호`, `fixes #이슈번호`, `resolves #이슈번호` 형식으로 작성해야 자동 닫기가 됩니다.

closes #35 

---

### 🧪 테스트 방법
> PR을 테스트한 방법이나 확인 결과를 적어주세요.

- [ ] 직접 테스트 완료
- [ ] Postman / Swagger로 API 확인
- [ ] 테스트 코드 통과

---

### 💬 기타 공유할 내용
> 리뷰어에게 공유할 내용이나 참고해야 할 사항이 있다면 자유롭게 작성해주세요.

-
