### PR TITLE
Refactor/43 requirements 2

### DIFF
--- a/deploy/k8s/app/shympyo-app-config.yaml
+++ b/deploy/k8s/app/shympyo-app-config.yaml
@@ -5,7 +5,7 @@ metadata:
 data:
   # server
   SERVER_PORT: "8080"
-
+  SPRING_PROFILES_ACTIVE: "prod"
   PUBLIC_BASE_URL: "https://shympyo.kro.kr"
 
 

--- a/src/main/java/shympyo/global/config/OpenApiConfigLocal.java
+++ b/src/main/java/shympyo/global/config/OpenApiConfigLocal.java
@@ -1,5 +1,6 @@
 package shympyo.global.config;
 
+import io.swagger.v3.oas.annotations.OpenAPIDefinition;
 import io.swagger.v3.oas.models.Components;
 import io.swagger.v3.oas.models.OpenAPI;
 import io.swagger.v3.oas.models.info.Info;
@@ -7,28 +8,24 @@ import io.swagger.v3.oas.models.security.SecurityRequirement;
 import io.swagger.v3.oas.models.security.SecurityScheme;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import io.swagger.v3.oas.annotations.servers.Server;
+import org.springframework.context.annotation.Profile;
 
+@Profile("local")
 @Configuration
-public class OpenApiConfig {
-
+@OpenAPIDefinition(
+        servers = { @Server(url = "http://localhost:8080", description = "Local") }
+)
+public class OpenApiConfigLocal {
     private static final String SECURITY_SCHEME_NAME = "BearerAuth";
-
     @Bean
     public OpenAPI openAPI() {
         return new OpenAPI()
-                .info(new Info()
-                        .title("Shympyo API")
-                        .version("v1")
-                        .description("Shympyo 백엔드 API 문서"))
+                .info(new Info().title("Shympyo API").version("v1").description("Shympyo 백엔드 API 문서"))
                 .components(new Components().addSecuritySchemes(
                         SECURITY_SCHEME_NAME,
-                        new SecurityScheme()
-                                .name(SECURITY_SCHEME_NAME)
-                                .type(SecurityScheme.Type.HTTP)
-                                .scheme("bearer")
-                                .bearerFormat("JWT")
+                        new SecurityScheme().name(SECURITY_SCHEME_NAME).type(SecurityScheme.Type.HTTP).scheme("bearer").bearerFormat("JWT")
                 ))
-                // 전역으로 JWT 요구(화이트리스트는 @Operation(security = {})로 해제)
                 .addSecurityItem(new SecurityRequirement().addList(SECURITY_SCHEME_NAME));
     }
 }

--- a/src/main/java/shympyo/global/config/OpenApiConfigProd.java
+++ b/src/main/java/shympyo/global/config/OpenApiConfigProd.java
@@ -1,0 +1,44 @@
+package shympyo.global.config;
+
+import io.swagger.v3.oas.annotations.OpenAPIDefinition;
+import io.swagger.v3.oas.models.Components;
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.info.Info;
+import io.swagger.v3.oas.models.security.SecurityRequirement;
+import io.swagger.v3.oas.models.security.SecurityScheme;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import io.swagger.v3.oas.annotations.servers.Server;
+import org.springframework.context.annotation.Profile;
+
+
+@Profile("prod")
+@Configuration
+@OpenAPIDefinition(
+        servers = {
+                @Server(url = "https://shympyo.kro.kr", description = "Prod")
+        }
+)
+public class OpenApiConfigProd {
+
+    private static final String SECURITY_SCHEME_NAME = "BearerAuth";
+
+    @Bean
+    public OpenAPI openAPI() {
+        return new OpenAPI()
+                .info(new Info()
+                        .title("Shympyo API")
+                        .version("v1")
+                        .description("Shympyo 백엔드 API 문서"))
+                .components(new Components().addSecuritySchemes(
+                        SECURITY_SCHEME_NAME,
+                        new SecurityScheme()
+                                .name(SECURITY_SCHEME_NAME)
+                                .type(SecurityScheme.Type.HTTP)
+                                .scheme("bearer")
+                                .bearerFormat("JWT")
+                ))
+                // 전역으로 JWT 요구(화이트리스트는 @Operation(security = {})로 해제)
+                .addSecurityItem(new SecurityRequirement().addList(SECURITY_SCHEME_NAME));
+    }
+}

--- a/src/main/java/shympyo/letter/controller/LetterController.java
+++ b/src/main/java/shympyo/letter/controller/LetterController.java
@@ -5,18 +5,19 @@ import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Slice;
+import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 import shympyo.auth.user.CustomUserDetails;
 import shympyo.global.response.CommonResponse;
+import shympyo.global.response.CursorPageResponse;
 import shympyo.global.response.ResponseUtil;
-import shympyo.letter.dto.CountLetterResponse;
-import shympyo.letter.dto.LetterResponse;
-import shympyo.letter.dto.SendLetterRequest;
-import shympyo.letter.dto.SendLetterResponse;
+import shympyo.letter.dto.*;
 import shympyo.letter.service.LetterService;
 
+import java.time.LocalDateTime;
 import java.util.List;
 
 @Tag(name = "Letter", description = "편지(쪽지) 관련 API")
@@ -31,17 +32,44 @@ public class LetterController {
             summary = "받은 편지함 조회",
             description = "장소를 제공한 제공자가 가게로 받은 편지 목록을 조회한다."
     )
-    @GetMapping("/received")
-    public ResponseEntity<CommonResponse<List<LetterResponse>>> getReceivedLetters(
-            @AuthenticationPrincipal CustomUserDetails owner) {
-        return ResponseUtil.success(letterService.getReceivedLetters(owner.getId()));
+    @GetMapping("/all")
+    public ResponseEntity<CommonResponse<CursorPageResponse<LetterHistoryResponse>>> getReceivedLetters(
+            @AuthenticationPrincipal CustomUserDetails owner,
+            @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME)
+            LocalDateTime cursorCreatedAt,
+            @RequestParam(required = false) Long cursorId,
+            @RequestParam(defaultValue = "20") int size)
+    {
+
+        return ResponseUtil.success("받은 편지 목록", letterService.getReceivedLetters(owner.getId(), cursorCreatedAt, cursorId, size));
     }
+
+    @GetMapping("/{letterId}")
+    public ResponseEntity<CommonResponse<LetterDetailResponse>> getDetailReceivedLetters(
+            @AuthenticationPrincipal CustomUserDetails owner,
+            @PathVariable Long letterId
+    ) {
+        return ResponseUtil.success(letterService.getReceivedLetterDetail(owner.getId(),letterId));
+    }
+
+    @Operation(
+            summary = "받은 편지 개수 조회",
+            description = "대여 장소를 제공한 제공자가 받은 편지의 개수를 조회한다."
+    )
+    @GetMapping("/count")
+    public ResponseEntity<CommonResponse<LetterCountResponse>> count(
+            @AuthenticationPrincipal CustomUserDetails owner) {
+
+        LetterCountResponse response = letterService.countLetter(owner.getId());
+        return ResponseUtil.success("받은 편지 개수 조회에 성공했습니다", response);
+    }
+
 
     @Operation(
             summary = "편지 보내기",
             description = "휴식을 한 장소로 편지를 전송한다."
     )
-    @PostMapping("/send")
+    @PostMapping
     public ResponseEntity<CommonResponse<SendLetterResponse>> send(
             @AuthenticationPrincipal CustomUserDetails writer,
             @Valid @RequestBody SendLetterRequest request) {
@@ -55,7 +83,7 @@ public class LetterController {
             description = "특정 편지를 읽음 상태로 변경한다."
     )
     @PostMapping("/{letterId}/read")
-    public ResponseEntity<CommonResponse<Void>> markRead(
+    public ResponseEntity<CommonResponse<Void>> read(
             @AuthenticationPrincipal CustomUserDetails owner,
             @Parameter(description = "편지 ID", example = "101") @PathVariable Long letterId) {
 
@@ -63,15 +91,4 @@ public class LetterController {
         return ResponseUtil.success("읽음 처리되었습니다.", null);
     }
 
-    @Operation(
-            summary = "받은 편지 개수 조회",
-            description = "대여 장소를 제공한 제공자가 받은 편지의 개수를 조회한다."
-    )
-    @GetMapping("/count")
-    public ResponseEntity<CommonResponse<CountLetterResponse>> count(
-            @AuthenticationPrincipal CustomUserDetails owner) {
-
-        CountLetterResponse response = letterService.countLetter(owner.getId());
-        return ResponseUtil.success("받은 편지 개수 조회에 성공했습니다", response);
-    }
 }

--- a/src/main/java/shympyo/letter/controller/LetterController.java
+++ b/src/main/java/shympyo/letter/controller/LetterController.java
@@ -44,6 +44,10 @@ public class LetterController {
         return ResponseUtil.success("받은 편지 목록", letterService.getReceivedLetters(owner.getId(), cursorCreatedAt, cursorId, size));
     }
 
+    @Operation(
+            summary = "편지 상세 조회",
+            description = "장소를 제공한 제공자가 가게로 받은 편지 내용을 조회한다."
+    )
     @GetMapping("/{letterId}")
     public ResponseEntity<CommonResponse<LetterDetailResponse>> getDetailReceivedLetters(
             @AuthenticationPrincipal CustomUserDetails owner,

--- a/src/main/java/shympyo/letter/domain/Letter.java
+++ b/src/main/java/shympyo/letter/domain/Letter.java
@@ -3,8 +3,7 @@ package shympyo.letter.domain;
 import jakarta.persistence.*;
 import lombok.*;
 import org.hibernate.annotations.CreationTimestamp;
-import org.springframework.data.jpa.domain.support.AuditingEntityListener;
-import shympyo.rental.domain.Place;
+import shympyo.rental.domain.Rental;
 import shympyo.user.domain.User;
 
 import java.time.LocalDateTime;
@@ -20,13 +19,13 @@ public class Letter {
     @ManyToOne(fetch = FetchType.LAZY) @JoinColumn(name = "writer_id", nullable = false)
     private User writer;
 
-    @ManyToOne(fetch = FetchType.LAZY) @JoinColumn(name = "place_id", nullable = false)
-    private Place place;
+    @OneToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "rental_id", nullable = false, unique = true)
+    private Rental rental;
 
     @Column(nullable = false, length = 2000)
     private String content;
 
-    /** 읽음 여부 + 읽은 시각 */
     @Column(nullable = false)
     private boolean isRead;
 
@@ -36,7 +35,6 @@ public class Letter {
     @Column(nullable = false, updatable = false)
     private LocalDateTime createdAt;
 
-    /** 읽음 처리 */
     public void markAsRead(LocalDateTime now) {
         if (!this.isRead) {
             this.isRead = true;

--- a/src/main/java/shympyo/letter/dto/LetterCountResponse.java
+++ b/src/main/java/shympyo/letter/dto/LetterCountResponse.java
@@ -7,7 +7,7 @@ import lombok.Getter;
 @AllArgsConstructor
 @Getter
 @Schema(description = "받은 편지 개수 응답 DTO")
-public class CountLetterResponse {
+public class LetterCountResponse {
 
     @Schema(description = "총 받은 편지 개수", example = "42")
     private Long total;

--- a/src/main/java/shympyo/letter/dto/LetterDetailResponse.java
+++ b/src/main/java/shympyo/letter/dto/LetterDetailResponse.java
@@ -8,28 +8,16 @@ import java.time.LocalDateTime;
 
 @Getter @AllArgsConstructor
 @Schema(description = "받은 편지 응답 DTO")
-public class LetterResponse {
+public class LetterDetailResponse {
 
     @Schema(description = "편지 ID", example = "101")
-    private Long id;
-
-    @Schema(description = "장소 ID", example = "5")
-    private Long placeId;
-
-    @Schema(description = "장소 이름", example = "쉼표 카페")
-    private String placeName;
-
-    @Schema(description = "작성자 정보")
-    private WriterInfo writerInfo;
+    private Long letterId;
 
     @Schema(description = "편지 내용", example = "오늘 카페 잘 이용했습니다!")
     private String content;
 
-    @Schema(description = "읽음 여부", example = "false")
-    private boolean isRead;
-
-    @Schema(description = "읽은 시간", example = "2025-09-20T13:45:00")
-    private LocalDateTime readAt;
+    @Schema(description = "작성자 정보")
+    private WriterInfo writerInfo;
 
     @Schema(description = "작성 시간", example = "2025-09-19T20:30:00")
     private LocalDateTime createdAt;

--- a/src/main/java/shympyo/letter/dto/LetterHistoryResponse.java
+++ b/src/main/java/shympyo/letter/dto/LetterHistoryResponse.java
@@ -1,0 +1,26 @@
+package shympyo.letter.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Builder
+@Getter @AllArgsConstructor
+public class LetterHistoryResponse {
+
+    @Schema(description = "편지 ID", example = "101")
+    private Long letterId;
+
+    @Schema(description = "작성자 정보")
+    private WriterInfo writerInfo;
+
+    @Schema(description = "작성 시간", example = "2025-09-19T20:30:00")
+    private LocalDateTime createdAt;
+
+    @Schema(description = "읽음 여부", example = "false")
+    private boolean isRead;
+
+}

--- a/src/main/java/shympyo/letter/dto/SendLetterRequest.java
+++ b/src/main/java/shympyo/letter/dto/SendLetterRequest.java
@@ -15,6 +15,10 @@ public class SendLetterRequest {
     @NotNull(message = "장소 ID는 필수입니다.")
     private Long placeId;
 
+    @Schema(description = "편지를 보낼 장소의 대여 기록 ID", example = "5")
+    @NotNull(message = "편지를 보낼 대여 ID는 필수입니다.")
+    private Long rentalId;
+
     @Schema(description = "메세지 내용", example = "오늘 이용 정말 좋았습니다!")
     @NotBlank(message = "메세지 내용은 필수입니다.")
     private String content;

--- a/src/main/java/shympyo/letter/dto/WriterInfo.java
+++ b/src/main/java/shympyo/letter/dto/WriterInfo.java
@@ -14,13 +14,13 @@ public class WriterInfo {
     @Schema(description = "작성자 ID", example = "77")
     private Long id;
 
-    @Schema(description = "작성자 이름", example = "홍길동")
-    private String name;
+    @Schema(description = "작성자 닉네임", example = "홍길동")
+    private String nickname;
 
-    @Schema(description = "작성자 이메일", example = "hong@example.com")
-    private String email;
+    @Schema(description = "자기 소개", example = "안녕하세요 사용자입니다! ")
+    private String bio;
 
-    @Schema(description = "작성자 전화번호", example = "010-1234-5678")
-    private String phone;
+    @Schema(description = "작성자 프로필 이미지 주소", example = "https~")
+    private String imageUrl;
 
 }

--- a/src/main/java/shympyo/letter/repository/LetterRepository.java
+++ b/src/main/java/shympyo/letter/repository/LetterRepository.java
@@ -1,35 +1,83 @@
 package shympyo.letter.repository;
 
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import shympyo.letter.domain.Letter;
 
+import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Optional;
 
 public interface LetterRepository extends JpaRepository<Letter, Long> {
 
-    // 장소 주인 받은 모든 편지 수
-    @Query("""
-        select count(l)
-        from Letter l
-        where l.place.owner.id = :ownerId
-    """)
-    long countAllByOwner(@Param("ownerId") Long ownerId);
+    boolean existsByRentalId(Long rentalId);
 
-    // 장소 주인이 받은 편지 중 안 읽은 것 개수
-    @Query("""
-      select count(l) from Letter l
-      where l.place.owner.id = :ownerId and l.isRead = false
-    """)
-    long countUnreadByOwner(@Param("ownerId") Long ownerId);
+    Optional<Letter> findByRentalId(Long rentalId);
 
-    // 받은 편지 목록 (최신순)
     @Query("""
       select l from Letter l
-      where l.place.owner.id = :ownerId
-      order by l.createdAt desc
+      join fetch l.writer w
+      join fetch l.rental r
+      join fetch r.place p
+      join fetch p.owner o
+      where l.id = :id
+    """)
+    Optional<Letter> findDetailById(@Param("id") Long id);
+
+    @Query("""
+        select l from Letter l
+        join l.rental r
+        join r.place p
+        where p.owner.id = :ownerId
+        order by l.createdAt desc
     """)
     List<Letter> findAllByOwner(@Param("ownerId") Long ownerId);
+
+    @Query("""
+        SELECT l
+        FROM Letter l
+        JOIN l.rental r
+        JOIN r.place p
+        WHERE p.owner.id = :ownerId
+        ORDER BY l.createdAt DESC, l.id DESC
+    """)
+    Slice<Letter> findReceivedByOwner(@Param("ownerId") Long ownerId,
+                                      Pageable pageable);
+
+    @Query("""
+      SELECT l
+      FROM Letter l
+      JOIN l.rental r
+      JOIN r.place p
+      WHERE p.owner.id = :ownerId
+        AND (
+             l.createdAt < :cursorCreatedAt
+          OR (l.createdAt = :cursorCreatedAt AND l.id < :cursorId)
+        )
+      ORDER BY l.createdAt DESC, l.id DESC
+    """)
+    Slice<Letter> findReceivedByOwnerWithCursor(@Param("ownerId") Long ownerId,
+                                                @Param("cursorCreatedAt") LocalDateTime cursorCreatedAt,
+                                                @Param("cursorId") Long cursorId,
+                                                Pageable pageable);
+
+    @Query("""
+        select count(l) from Letter l
+        join l.rental r
+        join r.place p
+        where p.owner.id = :ownerId
+    """)
+    Long countAllByOwner(@Param("ownerId") Long ownerId);
+
+    @Query("""
+        select count(l) from Letter l
+        join l.rental r
+        join r.place p
+        where p.owner.id = :ownerId and l.isRead = false
+    """)
+    Long countUnreadByOwner(@Param("ownerId") Long ownerId);
 
 }

--- a/src/main/java/shympyo/letter/repository/LetterRepository.java
+++ b/src/main/java/shympyo/letter/repository/LetterRepository.java
@@ -8,14 +8,16 @@ import org.springframework.data.repository.query.Param;
 import shympyo.letter.domain.Letter;
 
 import java.time.LocalDateTime;
-import java.util.List;
+import java.util.Collection;
 import java.util.Optional;
+import java.util.Set;
 
 public interface LetterRepository extends JpaRepository<Letter, Long> {
 
     boolean existsByRentalId(Long rentalId);
 
-    Optional<Letter> findByRentalId(Long rentalId);
+    @Query("select l.rental.id from Letter l where l.rental.id in :rentalIds")
+    Set<Long> findRentalIdsWithLetter(@Param("rentalIds") Collection<Long> rentalIds);
 
     @Query("""
       select l from Letter l
@@ -26,15 +28,6 @@ public interface LetterRepository extends JpaRepository<Letter, Long> {
       where l.id = :id
     """)
     Optional<Letter> findDetailById(@Param("id") Long id);
-
-    @Query("""
-        select l from Letter l
-        join l.rental r
-        join r.place p
-        where p.owner.id = :ownerId
-        order by l.createdAt desc
-    """)
-    List<Letter> findAllByOwner(@Param("ownerId") Long ownerId);
 
     @Query("""
         SELECT l

--- a/src/main/java/shympyo/map/controller/MapController.java
+++ b/src/main/java/shympyo/map/controller/MapController.java
@@ -10,6 +10,7 @@ import org.springframework.web.bind.annotation.*;
 import shympyo.global.response.CommonResponse;
 import shympyo.global.response.ResponseUtil;
 import shympyo.map.domain.PlaceType;
+import shympyo.map.dto.MapDetailResponse;
 import shympyo.map.dto.NearbyListResponse;
 import shympyo.map.dto.NearbyMapResponse;
 import shympyo.map.dto.PlaceDetailResponse;
@@ -109,7 +110,7 @@ public class MapController {
             description = "공공 데이터(Map)에 등록된 쉼터의 상세 정보를 조회한다."
     )
     @GetMapping("/public/{id}")
-    public ResponseEntity<CommonResponse<PlaceDetailResponse>> getMap(
+    public ResponseEntity<CommonResponse<MapDetailResponse>> getMap(
             @Parameter(description = "공공 쉼터 ID", example = "123")
             @PathVariable Long id
     ) {

--- a/src/main/java/shympyo/map/dto/MapDetailResponse.java
+++ b/src/main/java/shympyo/map/dto/MapDetailResponse.java
@@ -4,14 +4,10 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Builder;
 import lombok.Getter;
 import shympyo.map.domain.PlaceType;
-import shympyo.rental.domain.PlaceBusinessHour;
 
-import java.util.List;
-
-@Getter
 @Builder
-@Schema(description = "장소 상세 정보 응답 DTO")
-public class PlaceDetailResponse {
+@Getter
+public class MapDetailResponse {
 
     @Schema(description = "장소 ID", example = "7")
     private Long id;
@@ -25,18 +21,6 @@ public class PlaceDetailResponse {
     @Schema(description = "설명/소개", example = "16-023 강서세무서(중) 버스정류소")
     private String content;
 
-    @Schema(description = "최대 수용 인원", example = "5")
-    private Integer maxCapacity;
-
-    @Schema(description = "현재 이용 인원", example = "3")
-    private Integer currentCapacity;
-
-    @Schema(description = "영업 시간")
-    private PlaceTodayAndHolidayResponse todayAndHoliday;
-
-    @Schema(description = "이미지 주소")
-    private String imageUrl;
-
     @Schema(description = "위도", example = "37.5665")
     private double latitude;
 
@@ -45,4 +29,5 @@ public class PlaceDetailResponse {
 
     @Schema(description = "장소 유형", example = "CAFE")
     private PlaceType type;
+
 }

--- a/src/main/java/shympyo/map/dto/PlaceTodayAndHolidayResponse.java
+++ b/src/main/java/shympyo/map/dto/PlaceTodayAndHolidayResponse.java
@@ -1,0 +1,36 @@
+package shympyo.map.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.DayOfWeek;
+import java.time.LocalTime;
+import java.util.List;
+
+@Builder
+@Getter
+public class PlaceTodayAndHolidayResponse {
+
+    @Schema(description = "오늘 요일", example = "MONDAY")
+    private final DayOfWeek dayOfWeek;
+
+    @Schema(description = "오늘 휴무 여부", example = "false")
+    private final boolean closed;
+
+    @Schema(description = "영업 시작 시간(휴무일이면 null)")
+    private final LocalTime openTime;
+
+    @Schema(description = "영업 종료 시간(휴무일이면 null)")
+    private final LocalTime closeTime;
+
+    @Schema(description = "브레이크 시작 시간(없으면 null)")
+    private final LocalTime breakStart;
+
+    @Schema(description = "브레이크 종료 시간(없으면 null)")
+    private final LocalTime breakEnd;
+
+    @Schema(description = "휴무 요일 목록")
+    private final List<DayOfWeek> holidays;
+
+}

--- a/src/main/java/shympyo/rental/dto/UserRentalHistoryResponse.java
+++ b/src/main/java/shympyo/rental/dto/UserRentalHistoryResponse.java
@@ -27,4 +27,7 @@ public class UserRentalHistoryResponse {
 
     @Schema(description = "대여 종료 시간", example = "2025-09-01T12:00:00")
     private LocalDateTime endTime;
+
+    @Schema(description = "대여에 대한 편지 작성 여부", example = "true")
+    private Boolean isWritten;
 }

--- a/src/main/java/shympyo/rental/repository/PlaceBusinessHourRepository.java
+++ b/src/main/java/shympyo/rental/repository/PlaceBusinessHourRepository.java
@@ -17,5 +17,4 @@ public interface PlaceBusinessHourRepository extends JpaRepository<PlaceBusiness
 
     Optional<PlaceBusinessHour> findByPlaceIdAndDayOfWeek(Long placeId, DayOfWeek day);
 
-
-}
+    List<PlaceBusinessHour> findByPlaceIdAndClosedTrue(Long placeId);}

--- a/src/main/java/shympyo/rental/repository/RentalRepository.java
+++ b/src/main/java/shympyo/rental/repository/RentalRepository.java
@@ -19,6 +19,7 @@ public interface RentalRepository extends JpaRepository<Rental, Long> {
 
     long countByPlaceIdAndStatus(Long placeId, String status);
     boolean existsByUserIdAndStatus(Long userId, String status);
+    Optional<Rental> findByIdAndUserId(Long rentalId, Long userId);
 
     @Query("select r from Rental r where r.user.id = :userId and r.status = :status")
     List<Rental> findByUserIdAndStatus(@Param("userId") Long userId, @Param("status") String status);


### PR DESCRIPTION
## 📌 PR 제목 작성 규칙
> 아래 규칙 중 하나를 골라 제목 앞에 붙여주세요.
- [Feat] 기능 추가
- [Fix] 버그 수정
- [Refactor] 코드 리팩토링
- [Docs] 문서 수정
- [Chore] 기타 변경

---

## ✅ PR 내용

### ✨ 어떤 작업을 했나요?
> 작업한 내용을 간단히 요약해주세요.

### 1. 받은 편지함 API - 작성자 자기소개(bio) 필드 추가 및 편지 상세 열기 API 만들기
- 제공자 받은 편지 목록 보기와 편지 상세 보기로 구분했습니다.
- API가 분리됨에 따라 기존 API endpoint가 변경되었습니다. 

  기존
  ```
  /api/letters/received
  ```
  
  변경
  ```
  /api/letters/all
  /api/letters/{letterId}
  ```

- 받은 편지 목록은 커서 페이징 넣어서 구현했어요! 방식은 사용자가 쉼터 이용 기록 보기와 동일합니다.
  
  처음에는 
  ```
  http://localhost:8080/api/letters/all?size=10
  ```
  응답 값 중 hasnext가 true인 경우 다음 내용이 있다는 거니까 
  
  ```
  http://localhost:8080/api/letters/all?cursorCreatedAt={마지막 Letter의 createdAt}&cursorId={마지막 Letter의 letterId}&size={몇 개 받을건지}
  ```
  이렇게 하면 그 다음 내용이 나오게 됩니다. 

- 받은 편지 목록과 상세 보기 둘 다 자기소개 필드 추가했습니다.
- email이랑 휴대폰 번호 주게 되는데, 이건 필요없을거 같아서 삭제했습니다. 
- 이름을 닉네임으로 변경했습니다. 

### 2. 편지 중복 전송 방지 + Letter 엔티티 수정
- 일단 중복 전송 방지를 하기 위해서 그냥 연관 관계를 수정했습니다. 
- Place와 1대1 매핑을 대여 기록과 1대1 매핑으로 바꿔서 한번의 대여 당 한 번의 편지만 작성하도록 했습니다.
- 연관 관계가 수정됨에 따라 편지 작성할 때 rentalId를 넣어줘야 합니다. 자세한건 스웨거 확인 부탁!

### 3. 사용자 이용 내역 API에 편지 작성 여부 추가
- `letterSent` 대신에 `isWritten` 필드를 추가해서 쉼터 이용자가 자신이 사용한 쉼터 이력 조회할 때 추가했습니다.
-  그냥 필드만 넣어준거라 바뀐건 없습니다 .


### 6. 민간 개방 시설(USER_SHELTER) 현재 이용자 수 조회 
- 지도에서 핀 상세보기에 현재 이용 중인 사용자 수 추가 했습니다.
- 현재 이용 중인 사용자 수만 넣으면 총 인원수를 모를거 같아서 최대 이용 인원 수도 같이 넣어줬습니다.

---

### 🔗 관련 이슈
> 이 PR이 병합되면 자동으로 닫힐 이슈 번호를 적어주세요.  
> `closes #이슈번호`, `fixes #이슈번호`, `resolves #이슈번호` 형식으로 작성해야 자동 닫기가 됩니다.

예시: `closes #12`

closes #

---

### 🧪 테스트 방법
> PR을 테스트한 방법이나 확인 결과를 적어주세요.

- [ ] 직접 테스트 완료
- [ ] Postman / Swagger로 API 확인
- [ ] 테스트 코드 통과

---

### 💬 기타 공유할 내용
> 리뷰어에게 공유할 내용이나 참고해야 할 사항이 있다면 자유롭게 작성해주세요.

-
