### PR TITLE
[Feat] 신고/차단 서비스 구현

### DIFF
--- a/src/main/java/shympyo/global/config/JpaConfig.java
+++ b/src/main/java/shympyo/global/config/JpaConfig.java
@@ -1,0 +1,9 @@
+package shympyo.global.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+
+@Configuration
+@EnableJpaAuditing
+public class JpaConfig {
+}

--- a/src/main/java/shympyo/global/util/weather/controller/WeatherController.java
+++ b/src/main/java/shympyo/global/util/weather/controller/WeatherController.java
@@ -1,4 +1,4 @@
-package shympyo.weather.controller;
+package shympyo.global.util.weather.controller;
 
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
@@ -8,8 +8,8 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 import shympyo.global.response.CommonResponse;
 import shympyo.global.response.ResponseUtil;
-import shympyo.weather.dto.WeatherResponse;
-import shympyo.weather.service.WeatherService;
+import shympyo.global.util.weather.dto.WeatherResponse;
+import shympyo.global.util.weather.service.WeatherService;
 
 @Tag(name = "Weather", description = "날씨 정보 API")
 @RestController

--- a/src/main/java/shympyo/global/util/weather/dto/WeatherResponse.java
+++ b/src/main/java/shympyo/global/util/weather/dto/WeatherResponse.java
@@ -1,4 +1,4 @@
-package shympyo.weather.dto;
+package shympyo.global.util.weather.dto;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.AllArgsConstructor;

--- a/src/main/java/shympyo/global/util/weather/service/WeatherService.java
+++ b/src/main/java/shympyo/global/util/weather/service/WeatherService.java
@@ -1,4 +1,4 @@
-package shympyo.weather.service;
+package shympyo.global.util.weather.service;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -13,7 +13,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.web.client.RestClientException;
 import org.springframework.web.client.RestTemplate;
 import org.springframework.web.util.UriComponentsBuilder;
-import shympyo.weather.dto.WeatherResponse;
+import shympyo.global.util.weather.dto.WeatherResponse;
 
 @Slf4j
 @Service

--- a/src/main/java/shympyo/map/controller/MapController.java
+++ b/src/main/java/shympyo/map/controller/MapController.java
@@ -6,7 +6,9 @@ import io.swagger.v3.oas.annotations.media.ArraySchema;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
+import shympyo.auth.user.CustomUserDetails;
 import shympyo.global.response.CommonResponse;
 import shympyo.global.response.ResponseUtil;
 import shympyo.map.domain.PlaceType;
@@ -41,6 +43,8 @@ public class MapController {
     )
     @GetMapping("/nearby")
     public ResponseEntity<CommonResponse<List<NearbyMapResponse>>> nearby(
+            @AuthenticationPrincipal CustomUserDetails user,
+
             @Parameter(description = "위도", example = "37.5665")
             @RequestParam double lat,
 
@@ -61,7 +65,7 @@ public class MapController {
             )
             @RequestParam(name = "types", required = false) List<PlaceType> types
     ) {
-        return ResponseUtil.success(mapService.findNearby(lat, lon, radius, limit, types));
+        return ResponseUtil.success(mapService.findNearby(user.getId(), lat, lon, radius, limit, types));
     }
 
 
@@ -81,6 +85,8 @@ public class MapController {
     )
     @GetMapping("/nearby-list")
     public ResponseEntity<CommonResponse<List<NearbyListResponse>>> nearbyList(
+            @AuthenticationPrincipal CustomUserDetails user,
+
             @Parameter(description = "위도", example = "37.5665")
             @RequestParam double lat,
 
@@ -101,7 +107,7 @@ public class MapController {
             )
             @RequestParam(name = "types", required = false) List<PlaceType> types
     ) {
-        return ResponseUtil.success(mapService.findNearbyList(lat, lon, radius, limit, types));
+        return ResponseUtil.success(mapService.findNearbyList(user.getId(), lat, lon, radius, limit, types));
     }
 
 

--- a/src/main/java/shympyo/rental/controller/PlaceController.java
+++ b/src/main/java/shympyo/rental/controller/PlaceController.java
@@ -4,7 +4,6 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
-import org.apache.coyote.Response;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
@@ -14,6 +13,7 @@ import shympyo.global.response.ResponseUtil;
 import shympyo.rental.domain.PlaceStatus;
 import shympyo.rental.dto.*;
 import shympyo.rental.service.PlaceService;
+import shympyo.report.dto.ProviderBlockUserRequest;
 
 @RestController
 @RequestMapping("/api/places")

--- a/src/main/java/shympyo/rental/repository/PlaceRepository.java
+++ b/src/main/java/shympyo/rental/repository/PlaceRepository.java
@@ -13,12 +13,12 @@ import java.util.Optional;
 public interface PlaceRepository extends JpaRepository<Place, Long> {
 
     Optional<Place> findByCode(String code);
-
+    Optional<Place> findByOwnerId(Long ownerId);
+    boolean existsByIdAndOwnerId(Long placeId, Long ownerId);
     @Lock(LockModeType.PESSIMISTIC_WRITE)
     @Query("select p from Place p where p.code = :code")
     Optional<Place> findByCodeForUpdate(@Param("code") String code);
 
-    Optional<Place> findByOwnerId(Long ownerId);
 
 
     @Query("""

--- a/src/main/java/shympyo/rental/repository/RentalRepository.java
+++ b/src/main/java/shympyo/rental/repository/RentalRepository.java
@@ -16,7 +16,7 @@ import java.util.List;
 import java.util.Optional;
 
 public interface RentalRepository extends JpaRepository<Rental, Long> {
-
+    boolean existsByIdAndPlaceOwnerId(Long rentalId, Long ownerId);
     long countByPlaceIdAndStatus(Long placeId, String status);
     boolean existsByUserIdAndStatus(Long userId, String status);
     Optional<Rental> findByIdAndUserId(Long rentalId, Long userId);

--- a/src/main/java/shympyo/rental/service/PlaceService.java
+++ b/src/main/java/shympyo/rental/service/PlaceService.java
@@ -6,14 +6,18 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import shympyo.rental.domain.Place;
 import shympyo.rental.domain.PlaceStatus;
+import shympyo.report.dto.ProviderBlockUserRequest;
 import shympyo.rental.dto.PlaceCreateRequest;
 import shympyo.rental.dto.PlaceResponse;
 import shympyo.rental.dto.PlaceUpdateRequest;
 import shympyo.rental.repository.PlaceRepository;
+import shympyo.report.domain.SanctionSource;
+import shympyo.report.service.SanctionService;
 import shympyo.user.domain.User;
 import shympyo.user.domain.UserRole;
 import shympyo.user.repository.UserRepository;
 
+import java.time.LocalDateTime;
 import java.util.UUID;
 
 @Service
@@ -24,6 +28,7 @@ public class PlaceService {
 
     private final UserRepository userRepository;
     private final PlaceRepository placeRepository;
+    private final SanctionService sanctionService;
 
     @Transactional
     public PlaceResponse createPlace(Long userId, PlaceCreateRequest request) {

--- a/src/main/java/shympyo/report/controller/BlockController.java
+++ b/src/main/java/shympyo/report/controller/BlockController.java
@@ -1,0 +1,67 @@
+package shympyo.report.controller;
+
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+import shympyo.auth.user.CustomUserDetails;
+import shympyo.global.response.CommonResponse;
+import shympyo.global.response.ResponseUtil;
+import shympyo.report.dto.ProviderBlockUserDetailResponse;
+import shympyo.report.dto.ProviderBlockUserRequest;
+import shympyo.report.dto.ProviderBlockUserResponse;
+import shympyo.report.service.BlockService;
+
+import java.util.List;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/blocks")
+public class BlockController {
+
+    private final BlockService blockservice;
+
+
+    @PostMapping("/{userId}")
+    public ResponseEntity<CommonResponse<Long>> blockUser(
+            @AuthenticationPrincipal CustomUserDetails user,
+            @PathVariable Long userId,
+            @RequestBody @Valid ProviderBlockUserRequest req
+    ){
+
+        Long sanctionId = blockservice.blockUser(user.getId(), userId, req);
+        return ResponseUtil.success("해당 사용자를 차단했습니다.", sanctionId);
+    }
+
+    @GetMapping("/all")
+    public ResponseEntity<CommonResponse<List<ProviderBlockUserResponse>>> getMyBlockedUsers(
+            @AuthenticationPrincipal CustomUserDetails me
+    ) {
+        List<ProviderBlockUserResponse> users =
+                blockservice.getBlock(me.getId());
+        return ResponseUtil.success("차단한 사용자 목록을 조회했습니다.", users);
+    }
+
+
+    @GetMapping("/{userId}")
+    public ResponseEntity<CommonResponse<ProviderBlockUserDetailResponse>> getBlockDetail(
+            @AuthenticationPrincipal CustomUserDetails me,
+            @PathVariable Long userId
+    ) {
+        ProviderBlockUserDetailResponse detail =
+                blockservice.getBlockDetail(me.getId(), userId);
+        return ResponseUtil.success("차단 상세를 조회했습니다.", detail);
+    }
+
+
+    @DeleteMapping("/{userId}")
+    public ResponseEntity<CommonResponse> unblockUser(
+            @AuthenticationPrincipal CustomUserDetails user,
+            @PathVariable Long userId
+    ) {
+        blockservice.unblockUser(user.getId(), userId);
+        return ResponseUtil.success("해당 사용자의 차단을 해제했습니다.");
+
+    }
+}

--- a/src/main/java/shympyo/report/controller/BlockController.java
+++ b/src/main/java/shympyo/report/controller/BlockController.java
@@ -1,67 +1,128 @@
 package shympyo.report.controller;
 
-import jakarta.validation.Valid;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
-import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import shympyo.auth.user.CustomUserDetails;
 import shympyo.global.response.CommonResponse;
 import shympyo.global.response.ResponseUtil;
 import shympyo.report.dto.ProviderBlockUserDetailResponse;
-import shympyo.report.dto.ProviderBlockUserRequest;
 import shympyo.report.dto.ProviderBlockUserResponse;
+import shympyo.report.dto.ProviderBlockUserRequest;
 import shympyo.report.service.BlockService;
 
 import java.util.List;
 
+@Tag(name = "Provider Block", description = "제공자의 사용자 차단/해제/조회 API")
+@SecurityRequirement(name = "bearerAuth")
 @RestController
+@RequestMapping("/api/blocks/providers/me")
 @RequiredArgsConstructor
-@RequestMapping("/api/blocks")
 public class BlockController {
 
     private final BlockService blockservice;
 
-
+    @Operation(
+            summary = "특정 사용자 차단",
+            description = "제공자가 특정 사용자를 차단한다. 차단은 PLACE_ONLY로 저장되며 scopeRefId에는 제공자의 placeId가 매핑된다."
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "차단 성공",
+                    content = @Content(schema = @Schema(implementation = CommonResponse.class))),
+            @ApiResponse(responseCode = "400", description = "잘못된 요청"),
+            @ApiResponse(responseCode = "401", description = "인증 실패"),
+            @ApiResponse(responseCode = "403", description = "권한 없음"),
+            @ApiResponse(responseCode = "404", description = "대상 사용자를 찾을 수 없음")
+    })
     @PostMapping("/{userId}")
     public ResponseEntity<CommonResponse<Long>> blockUser(
-            @AuthenticationPrincipal CustomUserDetails user,
-            @PathVariable Long userId,
-            @RequestBody @Valid ProviderBlockUserRequest req
-    ){
-
+            @Parameter(hidden = true) @AuthenticationPrincipal CustomUserDetails user,
+            @Parameter(description = "차단할 사용자 ID", example = "123") @PathVariable Long userId,
+            @io.swagger.v3.oas.annotations.parameters.RequestBody(
+                    required = true,
+                    description = "차단 사유/메모 등 요청 본문",
+                    content = @Content(
+                            schema = @Schema(implementation = ProviderBlockUserRequest.class),
+                            examples = @ExampleObject(name = "기본 예시", value = """
+                            {
+                              "reason": "INAPPROPRIATE",
+                              "detail": "이용 중 부적절한 언행으로 인해 차단합니다.",
+                              "endAt": "2025-10-13T12:02:24.475509"
+                            }
+                            """)
+                    )
+            )
+            @RequestBody @jakarta.validation.Valid ProviderBlockUserRequest req
+    ) {
         Long sanctionId = blockservice.blockUser(user.getId(), userId, req);
         return ResponseUtil.success("해당 사용자를 차단했습니다.", sanctionId);
     }
 
+    @Operation(
+            summary = "내가 차단한 사용자 목록 조회",
+            description = "제공자가 차단한 사용자들의 요약 목록을 반환한다. 활성 제재만 반환하도록 구현되어 있다면 그에 맞춰 문서화한다."
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "조회 성공",
+                    content = @Content(schema = @Schema(implementation = CommonResponse.class))),
+            @ApiResponse(responseCode = "401", description = "인증 실패"),
+            @ApiResponse(responseCode = "403", description = "권한 없음")
+    })
     @GetMapping("/all")
     public ResponseEntity<CommonResponse<List<ProviderBlockUserResponse>>> getMyBlockedUsers(
-            @AuthenticationPrincipal CustomUserDetails me
+            @Parameter(hidden = true) @AuthenticationPrincipal CustomUserDetails me
     ) {
-        List<ProviderBlockUserResponse> users =
-                blockservice.getBlock(me.getId());
+        List<ProviderBlockUserResponse> users = blockservice.getBlock(me.getId());
         return ResponseUtil.success("차단한 사용자 목록을 조회했습니다.", users);
     }
 
-
+    @Operation(
+            summary = "차단 상세 조회",
+            description = "특정 사용자를 왜 차단했는지 상세 정보를 반환한다. 활성 제재만 조회한다면 그 기준을 명시한다."
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "조회 성공",
+                    content = @Content(schema = @Schema(implementation = CommonResponse.class))),
+            @ApiResponse(responseCode = "401", description = "인증 실패"),
+            @ApiResponse(responseCode = "403", description = "권한 없음"),
+            @ApiResponse(responseCode = "404", description = "차단 상세 없음")
+    })
     @GetMapping("/{userId}")
     public ResponseEntity<CommonResponse<ProviderBlockUserDetailResponse>> getBlockDetail(
-            @AuthenticationPrincipal CustomUserDetails me,
-            @PathVariable Long userId
+            @Parameter(hidden = true) @AuthenticationPrincipal CustomUserDetails me,
+            @Parameter(description = "상세를 조회할 사용자 ID", example = "123") @PathVariable Long userId
     ) {
-        ProviderBlockUserDetailResponse detail =
-                blockservice.getBlockDetail(me.getId(), userId);
+        ProviderBlockUserDetailResponse detail = blockservice.getBlockDetail(me.getId(), userId);
         return ResponseUtil.success("차단 상세를 조회했습니다.", detail);
     }
 
-
+    @Operation(
+            summary = "특정 사용자 차단 해제",
+            description = "제공자가 특정 사용자의 차단을 해제한다."
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "해제 성공",
+                    content = @Content(schema = @Schema(implementation = CommonResponse.class))),
+            @ApiResponse(responseCode = "401", description = "인증 실패"),
+            @ApiResponse(responseCode = "403", description = "권한 없음"),
+            @ApiResponse(responseCode = "404", description = "차단 내역 없음")
+    })
     @DeleteMapping("/{userId}")
     public ResponseEntity<CommonResponse> unblockUser(
-            @AuthenticationPrincipal CustomUserDetails user,
-            @PathVariable Long userId
+            @Parameter(hidden = true) @AuthenticationPrincipal CustomUserDetails user,
+            @Parameter(description = "차단 해제할 사용자 ID", example = "123") @PathVariable Long userId
     ) {
         blockservice.unblockUser(user.getId(), userId);
         return ResponseUtil.success("해당 사용자의 차단을 해제했습니다.");
-
     }
 }

--- a/src/main/java/shympyo/report/controller/ReportController.java
+++ b/src/main/java/shympyo/report/controller/ReportController.java
@@ -1,0 +1,30 @@
+package shympyo.report.controller;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+import shympyo.auth.user.CustomUserDetails;
+import shympyo.global.response.CommonResponse;
+import shympyo.global.response.ResponseUtil;
+import shympyo.report.dto.ProviderCreateReportRequest;
+import shympyo.report.service.ReportService;
+
+@RestController
+@RequestMapping("/api/reports")
+@RequiredArgsConstructor
+public class ReportController {
+
+    private final ReportService reportService;
+
+    @PostMapping
+    public ResponseEntity<CommonResponse> create(@AuthenticationPrincipal CustomUserDetails user,
+                                                 @RequestBody ProviderCreateReportRequest request){
+
+        reportService.report(user.getId(), request);
+
+        return ResponseUtil.success("성공적으로 신고했습니다.");
+    }
+
+
+}

--- a/src/main/java/shympyo/report/controller/ReportController.java
+++ b/src/main/java/shympyo/report/controller/ReportController.java
@@ -1,5 +1,11 @@
 package shympyo.report.controller;
 
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
@@ -10,6 +16,8 @@ import shympyo.global.response.ResponseUtil;
 import shympyo.report.dto.ProviderCreateReportRequest;
 import shympyo.report.service.ReportService;
 
+
+@Tag(name = "Report", description = "신고 관련 API (사용자 신고/조회 등)")
 @RestController
 @RequestMapping("/api/reports")
 @RequiredArgsConstructor
@@ -17,6 +25,28 @@ public class ReportController {
 
     private final ReportService reportService;
 
+    @Operation(
+            summary = "신고 생성",
+            description = """
+                    제공자가 사용자를 신고합니다.  
+                    요청 본문에는 신고 유형, 사유, 상세 내용을 포함해야 합니다.
+                    
+                    **ReportReason Enum 값**
+                    - `ABUSE` : 욕설, 괴롭힘 등
+                    - `INAPPROPRIATE` : 부적절한 언행/콘텐츠
+                    - `SCAM` : 사기/거짓 정보
+                    - `POLICY_VIOLATION` : 정책 위반
+                    - `OTHER` : 기타 사유
+                    """
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "신고 성공",
+                    content = @Content(schema = @Schema(implementation = CommonResponse.class))),
+            @ApiResponse(responseCode = "400", description = "요청 본문 형식 오류"),
+            @ApiResponse(responseCode = "401", description = "인증 실패"),
+            @ApiResponse(responseCode = "403", description = "권한 없음"),
+            @ApiResponse(responseCode = "500", description = "서버 오류")
+    })
     @PostMapping
     public ResponseEntity<CommonResponse> create(@AuthenticationPrincipal CustomUserDetails user,
                                                  @RequestBody ProviderCreateReportRequest request){

--- a/src/main/java/shympyo/report/domain/Report.java
+++ b/src/main/java/shympyo/report/domain/Report.java
@@ -1,0 +1,79 @@
+package shympyo.report.domain;
+
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+import shympyo.user.domain.User;
+
+import java.time.LocalDateTime;
+
+@Builder
+@Entity
+@EntityListeners(AuditingEntityListener.class)
+@AllArgsConstructor
+@NoArgsConstructor
+public class Report {
+
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "reporter_id", nullable = false)
+    private User reporter;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "reported_user_id", nullable = false)
+    private User reportedUser;
+
+    @Column(name = "rental_id")
+    private Long rentalId;
+
+    @Enumerated(EnumType.STRING)
+    @Column(length = 30, nullable = false)
+    private ReportReason reason;
+
+    @Column(columnDefinition = "TEXT")
+    private String content;
+
+    @Enumerated(EnumType.STRING)
+    @Column(length = 30, nullable = false)
+    @Builder.Default
+    private ReportStatus status = ReportStatus.PENDING;
+
+    @Enumerated(EnumType.STRING)
+    @Column(length = 30, nullable = false)
+    @Builder.Default
+    private ReportAction action = ReportAction.NONE;
+
+    @Column(columnDefinition = "TEXT")
+    private String adminNote;
+
+    private LocalDateTime processedAt;
+
+    @CreatedDate
+    @Column(updatable = false, nullable = false)
+    private LocalDateTime createdAt;
+
+    @LastModifiedDate
+    @Column(nullable = false)
+    private LocalDateTime updatedAt;
+
+    public void resolve(ReportAction action, String adminNote) {
+        this.status = ReportStatus.RESOLVED;
+        this.action = action == null ? ReportAction.NONE : action;
+        this.adminNote = adminNote;
+        this.processedAt = LocalDateTime.now();
+    }
+
+    public void reject(String adminNote) {
+        this.status = ReportStatus.REJECTED;
+        this.action = ReportAction.NONE;
+        this.adminNote = adminNote;
+        this.processedAt = LocalDateTime.now();
+    }
+
+}

--- a/src/main/java/shympyo/report/domain/ReportAction.java
+++ b/src/main/java/shympyo/report/domain/ReportAction.java
@@ -1,0 +1,8 @@
+package shympyo.report.domain;
+
+public enum ReportAction {
+    NONE,           // 조치 없음
+    HIDE_PLACE,     // 장소 숨김(지도 미노출)
+    SUSPEND_USER,   // 사용자 이용 정지
+    BLOCK_CONTENT   // 콘텐츠 차단(글/댓글/편지 등)
+}

--- a/src/main/java/shympyo/report/domain/ReportReason.java
+++ b/src/main/java/shympyo/report/domain/ReportReason.java
@@ -1,0 +1,11 @@
+package shympyo.report.domain;
+
+public enum ReportReason {
+
+    ABUSE,
+    INAPPROPRIATE,
+    SCAM,
+    POLICY_VIOLATION,
+    OTHER
+
+}

--- a/src/main/java/shympyo/report/domain/ReportStatus.java
+++ b/src/main/java/shympyo/report/domain/ReportStatus.java
@@ -1,0 +1,7 @@
+package shympyo.report.domain;
+
+public enum ReportStatus {
+    PENDING,
+    RESOLVED,
+    REJECTED
+}

--- a/src/main/java/shympyo/report/domain/ReportTargetType.java
+++ b/src/main/java/shympyo/report/domain/ReportTargetType.java
@@ -1,0 +1,8 @@
+package shympyo.report.domain;
+
+public enum ReportTargetType {
+    USER,
+    PLACE,
+    LETTER,
+    RENTAL
+}

--- a/src/main/java/shympyo/report/domain/Sanction.java
+++ b/src/main/java/shympyo/report/domain/Sanction.java
@@ -1,0 +1,128 @@
+package shympyo.report.domain;
+
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+import shympyo.map.domain.PlaceType;
+import shympyo.user.domain.User;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Builder
+@Entity
+@Table(
+        name = "sanction",
+        indexes = {
+                @Index(name = "idx_sanction_target_user", columnList = "target_user_id"),
+                @Index(name = "idx_sanction_status", columnList = "status"),
+                @Index(name = "idx_sanction_period", columnList = "startAt,endAt")
+        }
+)
+@NoArgsConstructor(access = lombok.AccessLevel.PROTECTED)
+@AllArgsConstructor(access = lombok.AccessLevel.PRIVATE)
+@EntityListeners(AuditingEntityListener.class)
+public class Sanction {
+
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    /** 제재 대상 사용자 */
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "target_user_id", nullable = false)
+    private User targetUser;
+
+    /** 제재 유형(경고/정지/차단 등) */
+    @Enumerated(EnumType.STRING)
+    @Column(length = 30, nullable = false)
+    private SanctionType type;
+
+    /** 제재 범위: 전체/특정 제공자/특정 장소 */
+    @Enumerated(EnumType.STRING)
+    @Column(length = 30, nullable = false)
+    private SanctionScope scope;
+
+    /** scope 보조키: PROVIDER_ONLY/PLACE_ONLY일 때 참조 ID(예: providerId, placeId) */
+    private Long scopeRefId;
+
+    /** PLACE_CATEGORY 등 enum 카테고리용 */
+    @Enumerated(EnumType.STRING)
+    @Column(length = 50)
+    private PlaceType scopeRefCategory;
+
+    /** 사유(카테고리) */
+    @Enumerated(EnumType.STRING)
+    @Column(length = 30, nullable = false)
+    private SanctionReason reason;
+
+    /** 상세 사유(운영 메모/근거 요약) */
+    @Column(columnDefinition = "TEXT")
+    private String detail;
+
+    @Column(nullable = false)
+    private LocalDateTime startAt;
+
+    private LocalDateTime endAt;
+
+    /** 진행 상태 */
+    @Enumerated(EnumType.STRING)
+    @Column(length = 20, nullable = false)
+    @Builder.Default
+    private SanctionStatus status = SanctionStatus.ACTIVE;
+
+    /** 생성 주체: MANUAL(관리자)/AUTO(임계치 자동) */
+    @Enumerated(EnumType.STRING)
+    @Column(length = 20, nullable = false)
+    private SanctionSource source;
+
+    @CreatedDate
+    @Column(updatable = false, nullable = false)
+    private LocalDateTime createdAt;
+
+    @LastModifiedDate
+    @Column(nullable = false)
+    private LocalDateTime updatedAt;
+
+    /* ===== 라이프사이클 ===== */
+    @PrePersist
+    void onCreate() {
+        if (this.startAt == null) this.startAt = LocalDateTime.now();
+    }
+
+    /* ===== 도메인 로직 ===== */
+    public boolean isActiveAt(LocalDateTime now) {
+        if (this.status != SanctionStatus.ACTIVE) return false;
+        boolean started = !now.isBefore(this.startAt);
+        boolean notEnded = (this.endAt == null) || now.isBefore(this.endAt);
+        return started && notEnded;
+    }
+
+    public void revoke(String note) {
+        this.status = SanctionStatus.REVOKED;
+        if (note != null && !note.isBlank()) {
+            this.detail = (this.detail == null ? "" : this.detail + "\n") + "[REVOKE] " + note;
+        }
+    }
+
+    public void expireNow() {
+        this.status = SanctionStatus.EXPIRED;
+        this.endAt = LocalDateTime.now();
+    }
+
+    public void extendUntil(LocalDateTime newEnd, String note) {
+        if (this.status != SanctionStatus.ACTIVE) return;
+        if (this.endAt == null || newEnd == null || newEnd.isAfter(this.endAt)) {
+            this.endAt = newEnd;
+        }
+        if (note != null && !note.isBlank()) {
+            this.detail = (this.detail == null || this.detail.isBlank())
+                    ? note
+                    : this.detail + "\n" + note;
+        }
+    }
+}

--- a/src/main/java/shympyo/report/domain/SanctionReason.java
+++ b/src/main/java/shympyo/report/domain/SanctionReason.java
@@ -1,0 +1,7 @@
+package shympyo.report.domain;
+
+public enum SanctionReason {
+
+    ABUSE, INAPPROPRIATE, SCAM, POLICY_VIOLATION, OTHER
+
+}

--- a/src/main/java/shympyo/report/domain/SanctionScope.java
+++ b/src/main/java/shympyo/report/domain/SanctionScope.java
@@ -1,0 +1,9 @@
+package shympyo.report.domain;
+
+public enum SanctionScope {
+
+    PLATFORM_ALL,   // 플랫폼 전체
+    PROVIDER_ONLY,  // 특정 제공자에 대해 제한
+    PLACE_ONLY,      // 특정 장소에 대해 제한
+    PLACE_CATEGORY
+}

--- a/src/main/java/shympyo/report/domain/SanctionSource.java
+++ b/src/main/java/shympyo/report/domain/SanctionSource.java
@@ -1,0 +1,5 @@
+package shympyo.report.domain;
+
+public enum SanctionSource {
+    MANUAL, AUTO
+}

--- a/src/main/java/shympyo/report/domain/SanctionStatus.java
+++ b/src/main/java/shympyo/report/domain/SanctionStatus.java
@@ -1,0 +1,5 @@
+package shympyo.report.domain;
+
+public enum SanctionStatus {
+    ACTIVE, EXPIRED, REVOKED
+}

--- a/src/main/java/shympyo/report/domain/SanctionType.java
+++ b/src/main/java/shympyo/report/domain/SanctionType.java
@@ -1,0 +1,10 @@
+package shympyo.report.domain;
+
+public enum SanctionType {
+
+    WARN,        // 경고
+    SUSPEND,     // 이용 정지
+    MUTE,        // 커뮤니케이션 제한
+    BLOCK_CONTENT
+
+}

--- a/src/main/java/shympyo/report/dto/ProviderBlockUserDetailResponse.java
+++ b/src/main/java/shympyo/report/dto/ProviderBlockUserDetailResponse.java
@@ -1,0 +1,25 @@
+package shympyo.report.dto;
+
+import lombok.*;
+import shympyo.report.domain.SanctionReason;
+import shympyo.report.domain.SanctionStatus;
+
+import java.time.LocalDateTime;
+
+@Builder
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class ProviderBlockUserDetailResponse {
+
+    private Long sanctionId;
+    private Long userId;
+    private String nickname;
+    private SanctionReason reason;
+    private String detail;
+    private LocalDateTime startAt;
+    private LocalDateTime endAt;
+    private SanctionStatus status;
+
+}

--- a/src/main/java/shympyo/report/dto/ProviderBlockUserRequest.java
+++ b/src/main/java/shympyo/report/dto/ProviderBlockUserRequest.java
@@ -1,0 +1,25 @@
+package shympyo.report.dto;
+
+import jakarta.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import shympyo.report.domain.SanctionReason;
+
+@Getter
+@Setter
+@AllArgsConstructor
+@NoArgsConstructor
+public class ProviderBlockUserRequest {
+
+
+    @NotNull
+    private Long placeId;
+
+    private SanctionReason reason = SanctionReason.OTHER;
+
+    private String detail;
+
+    private Integer durationDays;
+}

--- a/src/main/java/shympyo/report/dto/ProviderBlockUserResponse.java
+++ b/src/main/java/shympyo/report/dto/ProviderBlockUserResponse.java
@@ -1,0 +1,22 @@
+package shympyo.report.dto;
+
+
+import lombok.*;
+import shympyo.report.domain.SanctionStatus;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class ProviderBlockUserResponse {
+
+    private Long sanctionId;
+    private Long userId;
+    private String nickname;
+    private LocalDateTime startAt;
+    private SanctionStatus status;
+
+}

--- a/src/main/java/shympyo/report/dto/ProviderCreateReportRequest.java
+++ b/src/main/java/shympyo/report/dto/ProviderCreateReportRequest.java
@@ -1,0 +1,19 @@
+package shympyo.report.dto;
+
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+import shympyo.report.domain.ReportReason;
+
+@Getter
+public class ProviderCreateReportRequest {
+
+    @NotNull
+    private Long reportedUserId;
+
+    private Long rentalId;
+
+    @NotNull
+    private ReportReason reason;
+
+    private String content;
+}

--- a/src/main/java/shympyo/report/repository/ReportRepository.java
+++ b/src/main/java/shympyo/report/repository/ReportRepository.java
@@ -1,0 +1,36 @@
+package shympyo.report.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.stereotype.Repository;
+import shympyo.report.domain.Report;
+import shympyo.report.domain.ReportAction;
+import shympyo.report.domain.ReportStatus;
+
+import java.time.LocalDateTime;
+
+@Repository
+public interface ReportRepository extends JpaRepository<Report, Long> {
+
+    boolean existsByRentalIdAndReportedUserId(Long rentalId, Long reportedUserId);
+
+    long countByReportedUserIdAndStatus(Long reportedUserId, ReportStatus status);
+
+    @Modifying(clearAutomatically = true, flushAutomatically = true)
+    @Query("""
+    update Report r
+       set r.status = :resolvedStatus,
+           r.action = :action,
+           r.adminNote = concat(coalesce(r.adminNote, ''), :note),
+           r.processedAt = :now
+     where r.reportedUser.id = :userId
+       and r.status = :pendingStatus
+    """)
+    int resolveAllPendingByUser(Long userId,
+                                ReportStatus pendingStatus,
+                                ReportStatus resolvedStatus,
+                                ReportAction action,
+                                String note,
+                                LocalDateTime now);
+}

--- a/src/main/java/shympyo/report/repository/SanctionRepository.java
+++ b/src/main/java/shympyo/report/repository/SanctionRepository.java
@@ -1,0 +1,144 @@
+package shympyo.report.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+import shympyo.map.domain.PlaceType;
+import shympyo.report.domain.Sanction;
+import shympyo.report.domain.SanctionScope;
+import shympyo.report.domain.SanctionType;
+import shympyo.report.dto.ProviderBlockUserDetailResponse;
+import shympyo.report.dto.ProviderBlockUserResponse;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+
+@Repository
+public interface SanctionRepository extends JpaRepository<Sanction, Long> {
+
+    @Query("""
+        select s
+        from Sanction s
+        where s.targetUser.id = :userId
+          and s.type = :type
+          and s.scope = :scope
+          and ((:scopeRefId is null and s.scopeRefId is null) or s.scopeRefId = :scopeRefId)
+          and s.status = shympyo.report.domain.SanctionStatus.ACTIVE
+          and s.startAt <= :now
+          and (s.endAt is null or s.endAt > :now)
+    """)
+    Optional<Sanction> findActiveNow(Long userId,
+                                     SanctionType type,
+                                     SanctionScope scope,
+                                     Long scopeRefId,
+                                     LocalDateTime now);
+
+    @Query("""
+    select s from Sanction s
+    where s.targetUser.id = :userId
+      and s.type = :type
+      and s.scope = :scope
+      and s.scopeRefId = :placeId
+      and s.status = shympyo.report.domain.SanctionStatus.ACTIVE
+      and s.startAt <= :now
+      and (s.endAt is null or s.endAt > :now)
+    """)
+    Optional<Sanction> findActiveNowByPlace(Long userId, SanctionType type, SanctionScope scope,
+                                            Long placeId, LocalDateTime now);
+
+    @Query("""
+    select s from Sanction s
+    where s.targetUser.id = :userId
+      and s.type = :type
+      and s.scope = :scope
+      and s.scopeRefCategory = :category
+      and s.status = shympyo.report.domain.SanctionStatus.ACTIVE
+      and s.startAt <= :now
+      and (s.endAt is null or s.endAt > :now)
+    """)
+    Optional<Sanction> findActiveNowByCategory(Long userId, SanctionType type, SanctionScope scope,
+                                               PlaceType category, LocalDateTime now);
+
+    @Query("""
+        SELECT new shympyo.report.dto.ProviderBlockUserResponse(
+            s.id, u.id, u.nickname, s.startAt, s.status
+        )
+        FROM Sanction s
+        JOIN s.targetUser u
+        WHERE s.type  = shympyo.report.domain.SanctionType.BLOCK_CONTENT
+          AND s.scope = shympyo.report.domain.SanctionScope.PLACE_ONLY
+          AND s.scopeRefId = :placeId
+          AND s.status = shympyo.report.domain.SanctionStatus.ACTIVE
+          AND s.startAt <= :now
+          AND (s.endAt IS NULL OR s.endAt > :now)
+        ORDER BY s.startAt DESC, s.id DESC
+    """)
+    List<ProviderBlockUserResponse> findActiveBlockedUsers(
+            @Param("placeId") Long placeId,
+            @Param("now") LocalDateTime now
+    );
+
+    @Query("""
+        SELECT new shympyo.report.dto.ProviderBlockUserDetailResponse(
+            s.id, u.id, u.nickname, s.reason, s.detail, s.startAt, s.endAt, s.status
+        )
+        FROM Sanction s
+        JOIN s.targetUser u
+        WHERE s.type  = shympyo.report.domain.SanctionType.BLOCK_CONTENT
+          AND s.scope = shympyo.report.domain.SanctionScope.PLACE_ONLY
+          AND s.scopeRefId = :placeId
+          AND u.id = :userId
+          AND s.status = shympyo.report.domain.SanctionStatus.ACTIVE
+          AND s.startAt <= :now
+          AND (s.endAt IS NULL OR s.endAt > :now)
+    """)
+    Optional<ProviderBlockUserDetailResponse> findActiveBlockDetail(
+            @Param("placeId") Long placeId,
+            @Param("userId") Long userId,
+            @Param("now") LocalDateTime now
+    );
+
+
+    @Query("""
+        SELECT COUNT(s) > 0
+        FROM Sanction s
+        WHERE s.targetUser.id = :userId
+          AND s.type = :type
+          AND s.scope = :scope
+          AND s.scopeRefCategory = :category
+          AND s.status = 'ACTIVE'
+          AND (s.endAt IS NULL OR s.endAt > :now)
+    """)
+    boolean existsActiveCategoryBlock(
+            @Param("userId") Long userId,
+            @Param("type") SanctionType type,
+            @Param("scope") SanctionScope scope,
+            @Param("category") PlaceType category,
+            @Param("now") LocalDateTime now);
+
+
+    @Query("""
+        SELECT (COUNT(s) > 0)
+        FROM Sanction s
+        WHERE s.targetUser.id = :targetUserId
+          AND s.type = :type
+          AND s.scope = :scope
+          AND s.scopeRefId = :placeId
+          AND s.status = shympyo.report.domain.SanctionStatus.ACTIVE
+          AND s.startAt <= :now
+          AND (s.endAt IS NULL OR s.endAt > :now)
+    """)
+    boolean existsActivePlaceBlock(
+            @Param("targetUserId") Long targetUserId,     // 차단당한 사용자 ID
+            @Param("type") SanctionType type,             // BLOCK_CONTENT
+            @Param("scope") SanctionScope scope,          // PLACE_ONLY
+            @Param("placeId") Long placeId,               // 장소 ID
+            @Param("now") LocalDateTime now
+    );
+
+
+
+
+}

--- a/src/main/java/shympyo/report/service/BlockService.java
+++ b/src/main/java/shympyo/report/service/BlockService.java
@@ -1,0 +1,110 @@
+package shympyo.report.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import shympyo.rental.domain.Place;
+import shympyo.rental.repository.PlaceRepository;
+import shympyo.report.domain.SanctionSource;
+import shympyo.report.dto.ProviderBlockUserDetailResponse;
+import shympyo.report.dto.ProviderBlockUserRequest;
+import shympyo.report.dto.ProviderBlockUserResponse;
+import shympyo.report.repository.SanctionRepository;
+import shympyo.user.domain.User;
+import shympyo.user.domain.UserRole;
+import shympyo.user.repository.UserRepository;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class BlockService {
+
+    private final UserRepository userRepository;
+    private final PlaceRepository placeRepository;
+    private final SanctionRepository sanctionRepository;
+
+    private final SanctionService sanctionService;
+
+    public List<ProviderBlockUserResponse> getBlock(Long providerId) {
+
+        User provider = userRepository.findById(providerId)
+                .orElseThrow(() -> new IllegalArgumentException("해당 사용자를 찾을 수 없습니다."));
+
+        Place place = placeRepository.findByOwnerId(provider.getId())
+                .orElseThrow(() -> new IllegalArgumentException("해당 사용자의 장소를 찾을 수 없습니다.") );
+
+        return sanctionRepository.findActiveBlockedUsers(
+                place.getId(),
+                LocalDateTime.now()
+        );
+    }
+
+    public ProviderBlockUserDetailResponse getBlockDetail(Long providerId, Long userId) {
+
+        User provider = userRepository.findById(providerId)
+                .orElseThrow(() -> new IllegalArgumentException("해당 사용자를 찾을 수 없습니다."));
+
+        Place place = placeRepository.findByOwnerId(provider.getId())
+                .orElseThrow(() -> new IllegalArgumentException("해당 사용자의 장소를 찾을 수 없습니다.") );
+
+        return sanctionRepository.findActiveBlockDetail(
+                        place.getId(),
+                        userId,
+                        LocalDateTime.now()
+                )
+                .orElseThrow(() -> new IllegalArgumentException("차단 상세 내역이 없습니다."));
+    }
+
+    @Transactional
+    public Long blockUser(Long userId,Long targetUserId, ProviderBlockUserRequest req) {
+
+        User provider = userRepository.findById(userId)
+                .orElseThrow(() -> new IllegalArgumentException("사용자를 찾을 수 없습니다."));
+        if (provider.getRole() != UserRole.PROVIDER) {
+            throw new IllegalArgumentException("장소 제공자만 차단할 수 있습니다.");
+        }
+        if (provider.getId().equals(targetUserId)) {
+            throw new IllegalArgumentException("자기 자신은 차단할 수 없습니다.");
+        }
+
+        userRepository.findById(targetUserId)
+                .orElseThrow(() -> new IllegalArgumentException("차단 대상 사용자를 찾을 수 없습니다."));
+        if (!placeRepository.existsByIdAndOwnerId(req.getPlaceId(), provider.getId())) {
+            throw new IllegalArgumentException("해당 장소는 이 제공자의 소유가 아닙니다.");
+        }
+
+        LocalDateTime startAt = LocalDateTime.now();
+        LocalDateTime endAt = (req.getDurationDays() == null || req.getDurationDays() <= 0)
+                ? null : startAt.plusDays(req.getDurationDays());
+
+        String detail = req.getDetail();
+        if (detail == null || detail.isBlank()) {
+            detail = "provider=" + provider.getId() + ", place=" + req.getPlaceId();
+        }
+
+        return sanctionService.issueBlockContentByPlace(
+                targetUserId,
+                req.getPlaceId(),
+                req.getReason(),
+                detail,
+                startAt,
+                endAt,
+                SanctionSource.MANUAL
+        );
+    }
+
+    @Transactional
+    public void unblockUser(Long providerId, Long targetUserId) {
+        User provider = userRepository.findById(providerId)
+                .orElseThrow(() -> new IllegalArgumentException("제공자를 찾을 수 없습니다."));
+
+        Place place = placeRepository.findByOwnerId(provider.getId())
+                .orElseThrow(()-> new IllegalArgumentException("제공하는 장소가 없습니다."));
+
+        sanctionService.revokeBlockContentByPlace(targetUserId, place.getId())
+                .orElseThrow(() -> new IllegalArgumentException("활성화된 차단 내역이 없습니다."));
+    }
+
+}

--- a/src/main/java/shympyo/report/service/ReportService.java
+++ b/src/main/java/shympyo/report/service/ReportService.java
@@ -1,0 +1,104 @@
+package shympyo.report.service;
+
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import shympyo.map.domain.PlaceType;
+import shympyo.rental.repository.RentalRepository;
+import shympyo.report.domain.*;
+import shympyo.report.dto.ProviderCreateReportRequest;
+import shympyo.report.repository.ReportRepository;
+import shympyo.user.domain.User;
+import shympyo.user.domain.UserRole;
+import shympyo.user.repository.UserRepository;
+
+import java.time.LocalDateTime;
+
+@Service
+@RequiredArgsConstructor
+public class ReportService {
+
+    private static final int REPORT_THRESHOLD = 3;       // 임계값
+
+    private final UserRepository userRepository;
+    private final ReportRepository reportRepository;
+    private final RentalRepository rentalRepository;
+    private final SanctionService sanctionService;
+
+    @Transactional
+    public void report(Long reporterId, ProviderCreateReportRequest request) {
+
+        User reporter = userRepository.findById(reporterId)
+                .orElseThrow(() -> new IllegalArgumentException("제공자를 찾을 수 없습니다."));
+        if (reporter.getRole() != UserRole.PROVIDER) {
+            throw new IllegalArgumentException("장소 제공자만 신고할 수 있습니다.");
+        }
+
+        User reported = userRepository.findById(request.getReportedUserId())
+                .orElseThrow(() -> new IllegalArgumentException("신고 대상 사용자를 찾을 수 없습니다."));
+
+        if (reported.getId().equals(reporter.getId())) {
+            throw new IllegalArgumentException("자기 자신은 신고할 수 없습니다.");
+        }
+
+        if (request.getRentalId() != null) {
+            boolean validRental = rentalRepository.existsByIdAndPlaceOwnerId(request.getRentalId(), reporter.getId());
+            if (!validRental) {
+                throw new IllegalArgumentException("해당 대여 건은 이 제공자의 장소에서 발생한 기록이 아닙니다.");
+            }
+        }
+
+        if (request.getRentalId() != null &&
+                reportRepository.existsByRentalIdAndReportedUserId(request.getRentalId(), request.getReportedUserId())) {
+            throw new IllegalArgumentException("이미 해당 대여 건에서 이 사용자를 신고했습니다.");
+        }
+
+        reportRepository.save(
+                Report.builder()
+                        .reporter(reporter)
+                        .reportedUser(reported)
+                        .rentalId(request.getRentalId())
+                        .reason(request.getReason())
+                        .content(request.getContent())
+                        .build()
+        );
+
+
+
+        long pendingCount = reportRepository.countByReportedUserIdAndStatus(
+                request.getReportedUserId(), ReportStatus.PENDING);
+
+        if (pendingCount >= REPORT_THRESHOLD) {
+
+
+            Long sanctionId = sanctionService.issueBlockContentByCategory(
+                    reported.getId(),
+                    PlaceType.USER_SHELTER,
+                    SanctionReason.POLICY_VIOLATION,
+                    "제공자 쉼터만 미노출",
+                    LocalDateTime.now(),
+                    LocalDateTime.now().plusDays(7),
+                    SanctionSource.MANUAL
+            );
+
+            String note = "\n[AUTO] sanctionId=" + sanctionId + "로 자동 종결";
+            reportRepository.resolveAllPendingByUser(
+                    reported.getId(),
+                    ReportStatus.PENDING,
+                    ReportStatus.RESOLVED,
+                    ReportAction.BLOCK_CONTENT, // 제재 타입에 맞게
+                    note,
+                    LocalDateTime.now());
+        }
+
+
+    }
+
+    public getReport(){
+
+    }
+
+
+
+}

--- a/src/main/java/shympyo/report/service/ReportService.java
+++ b/src/main/java/shympyo/report/service/ReportService.java
@@ -95,10 +95,4 @@ public class ReportService {
 
     }
 
-    public getReport(){
-
-    }
-
-
-
 }

--- a/src/main/java/shympyo/report/service/SanctionService.java
+++ b/src/main/java/shympyo/report/service/SanctionService.java
@@ -1,0 +1,182 @@
+package shympyo.report.service;
+
+import lombok.AllArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import shympyo.map.domain.PlaceType;
+import shympyo.report.domain.*;
+import shympyo.report.repository.SanctionRepository;
+import shympyo.user.domain.User;
+import shympyo.user.repository.UserRepository;
+
+import java.time.LocalDateTime;
+import java.util.Optional;
+
+@Service
+@AllArgsConstructor
+public class SanctionService {
+
+    private final SanctionRepository sanctionRepository;
+    private final UserRepository userRepository;
+
+    @Transactional
+    public Long issueSuspend(Long targetUserId,
+                             SanctionScope scope,
+                             Long scopeRefId,
+                             SanctionType type,
+                             SanctionReason reason,
+                             String detail,
+                             LocalDateTime startAt,
+                             LocalDateTime endAt,
+                             SanctionSource source) {
+
+        if (type != SanctionType.SUSPEND) {
+            throw new IllegalArgumentException("issueSuspend는 SanctionType.SUSPEND만 허용합니다.");
+        }
+        if (targetUserId == null) {
+            throw new IllegalArgumentException("targetUserId는 필수입니다.");
+        }
+        if (startAt == null) startAt = LocalDateTime.now();
+        if (endAt != null && endAt.isBefore(startAt)) {
+            throw new IllegalArgumentException("제재 종료 시각이 시작 시각보다 빠릅니다.");
+        }
+
+        User target = userRepository.findById(targetUserId)
+                .orElseThrow(() -> new IllegalArgumentException("제재 대상 사용자를 찾을 수 없습니다."));
+
+        LocalDateTime now = LocalDateTime.now();
+
+
+        final LocalDateTime start = (startAt == null) ? LocalDateTime.now() : startAt;
+        final LocalDateTime end = endAt;
+
+
+        return sanctionRepository.findActiveNow(targetUserId, type, scope, scopeRefId, now)
+                .map(active -> {
+                    active.extendUntil(endAt, "[EXTEND] " + (detail == null ? "" : detail));
+                    return active.getId();
+                })
+                .orElseGet(() -> {
+
+                    Sanction created = Sanction.builder()
+                            .targetUser(target)
+                            .type(type)
+                            .scope(scope)
+                            .scopeRefId(scopeRefId)
+                            .reason(reason)
+                            .detail(detail)
+                            .startAt(start)
+                            .endAt(end)
+                            .status(SanctionStatus.ACTIVE)
+                            .source(source)
+                            .build();
+
+                    return sanctionRepository.save(created).getId();
+                });
+    }
+
+    @Transactional
+    public Long issueBlockContentByPlace(Long targetUserId,
+                                         Long placeId,
+                                         SanctionReason reason,
+                                         String detail,
+                                         LocalDateTime startAt,
+                                         LocalDateTime endAt,
+                                         SanctionSource source) {
+        if (targetUserId == null || placeId == null)
+            throw new IllegalArgumentException("targetUserId/placeId는 필수입니다.");
+        if (startAt == null) startAt = LocalDateTime.now();
+        if (endAt != null && endAt.isBefore(startAt))
+            throw new IllegalArgumentException("종료가 시작보다 빠릅니다.");
+
+        User target = userRepository.findById(targetUserId)
+                .orElseThrow(() -> new IllegalArgumentException("제재 대상 사용자를 찾을 수 없습니다."));
+
+        LocalDateTime now = LocalDateTime.now();
+
+        final LocalDateTime start = startAt;
+        final LocalDateTime end = endAt;
+        final Long refPlaceId = placeId;
+
+        return sanctionRepository.findActiveNowByPlace(
+                        targetUserId, SanctionType.BLOCK_CONTENT, SanctionScope.PLACE_ONLY, refPlaceId, now)
+                .map(s -> {
+                    s.extendUntil(end, "[EXTEND] " + (detail == null ? "" : detail));
+                    return s.getId();
+                })
+                .orElseGet(() -> sanctionRepository.save(
+                        Sanction.builder()
+                                .targetUser(target)
+                                .type(SanctionType.BLOCK_CONTENT)
+                                .scope(SanctionScope.PLACE_ONLY)
+                                .scopeRefId(refPlaceId)
+                                .reason(reason)
+                                .detail(detail)
+                                .startAt(start)
+                                .endAt(end)
+                                .status(SanctionStatus.ACTIVE)
+                                .source(source)
+                                .build()
+                ).getId());
+    }
+
+
+    @Transactional
+    public Long issueBlockContentByCategory(Long targetUserId,
+                                            PlaceType category,
+                                            SanctionReason reason,
+                                            String detail,
+                                            LocalDateTime startAt,
+                                            LocalDateTime endAt,
+                                            SanctionSource source) {
+        if (targetUserId == null || category == null)
+            throw new IllegalArgumentException("targetUserId/category는 필수입니다.");
+        if (startAt == null) startAt = LocalDateTime.now();
+        if (endAt != null && endAt.isBefore(startAt))
+            throw new IllegalArgumentException("종료가 시작보다 빠릅니다.");
+
+        User target = userRepository.findById(targetUserId)
+                .orElseThrow(() -> new IllegalArgumentException("제재 대상 사용자를 찾을 수 없습니다."));
+
+        LocalDateTime now = LocalDateTime.now();
+
+        final LocalDateTime start = (startAt == null) ? LocalDateTime.now() : startAt;
+        final LocalDateTime end = endAt;
+
+        return sanctionRepository.findActiveNowByCategory(targetUserId, SanctionType.BLOCK_CONTENT,
+                        SanctionScope.PLACE_CATEGORY, category, now)
+                .map(s -> { s.extendUntil(endAt, "[EXTEND] " + (detail == null ? "" : detail)); return s.getId(); })
+                .orElseGet(() -> sanctionRepository.save(
+                        Sanction.builder()
+                                .targetUser(target)
+                                .type(SanctionType.BLOCK_CONTENT)
+                                .scope(SanctionScope.PLACE_CATEGORY)
+                                .scopeRefCategory(category)
+                                .reason(reason)
+                                .detail(detail)
+                                .startAt(start)
+                                .endAt(end)
+                                .status(SanctionStatus.ACTIVE)
+                                .source(source)
+                                .build()
+                ).getId());
+    }
+
+
+    @Transactional
+    public Optional<Long> revokeBlockContentByPlace(Long targetUserId, Long placeId) {
+        LocalDateTime now = LocalDateTime.now();
+
+        return sanctionRepository.findActiveNowByPlace(
+                targetUserId,
+                SanctionType.BLOCK_CONTENT,
+                SanctionScope.PLACE_ONLY,
+                placeId,
+                now
+        ).map(s -> {
+            s.revoke("제공자 요청으로 장소 차단 해제");
+            return s.getId();
+        });
+    }
+
+}


### PR DESCRIPTION
## ✅ PR 내용

### ✨ 어떤 작업을 했나요?
> 작업한 내용을 간단히 요약해주세요.

#### 신고 기능

- 사용자 신고 기능을 구현했습니다.

- 동일 사용자가 3회 이상 신고될 경우, 자동으로 제재(Sanction) 가 생성되도록 처리했습니다.

- 제재가 발생하면 기존 신고들의 상태는 PENDING → RESOLVED 로 변경됩니다.

- 제재된 사용자가 등록한 민간 쉼터는 지도에 표시되지 않도록 설정했습니다.

- 기본 제재 기간은 1주일(7일) 로 설정되었습니다.

#### 차단 기능
- 제공자가 특정 사용자를 차단할 수 있도록 차단 기능을 구현했습니다.
- 기존에 존재하던 제재 엔티티(Sanction) 를 활용하여, 제공자가 사용자를 차단하면
- 해당 제공자가 소유한 장소(Place) 에 대한 제재 항목이 자동 생성됩니다.
- 차단된 사용자는 해당 쉼터가 지도에서 보이지 않도록 필터링됩니다

---

### 🔗 관련 이슈
> 이 PR이 병합되면 자동으로 닫힐 이슈 번호를 적어주세요.  
> `closes #이슈번호`, `fixes #이슈번호`, `resolves #이슈번호` 형식으로 작성해야 자동 닫기가 됩니다.

예시: `closes #12`

closes #48

---

### 🧪 테스트 방법
> PR을 테스트한 방법이나 확인 결과를 적어주세요.

- [ ] 직접 테스트 완료
- [ ] Postman / Swagger로 API 확인
- [ ] 테스트 코드 통과

---

### 💬 기타 공유할 내용
> 리뷰어에게 공유할 내용이나 참고해야 할 사항이 있다면 자유롭게 작성해주세요.

-
