### PR TITLE
[Feat] 쉼터 이미지 Presigned URL 업로드 기능 추가

### DIFF
--- a/src/main/java/shympyo/rental/controller/PlaceImageController.java
+++ b/src/main/java/shympyo/rental/controller/PlaceImageController.java
@@ -1,0 +1,76 @@
+package shympyo.rental.controller;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import shympyo.auth.user.CustomUserDetails;
+import shympyo.global.response.CommonResponse;
+import shympyo.global.response.ResponseUtil;
+import shympyo.rental.dto.PlaceImagePresignRequest;
+import shympyo.storage.dto.PresignResponse;
+import shympyo.storage.service.ImagePresignService;
+
+@RestController
+@RequestMapping("/api/place-image")
+@RequiredArgsConstructor
+public class PlaceImageController {
+
+    private final ImagePresignService profileImageService;
+
+    @Operation(
+            summary = "장소 이미지 업로드용 presigned URL 발급",
+            description = """
+                    Naver Cloud Object Storage에 장소 이미지를 직접 업로드할 수 있는 presigned PUT URL을 발급합니다.
+                    
+                    **요청 흐름**
+                    1. 이 API 호출 → uploadUrl, publicUrl, objectKey 반환
+                    2. 클라이언트가 uploadUrl로 PUT 업로드
+                    3. 업로드 완료 후 publicUrl을 place 수정 API로 전달하여 저장
+                    4. places의 쉼터 수정 이용해서 imageUrl 수정 필요
+                    
+                    **주의사항**
+                    - 업로드 시 헤더:
+                      - Content-Type: 요청 시 전달한 값과 동일 (예: image/jpeg)
+                      - x-amz-acl: public-read
+                    - 헤더 불일치 시 403(SignatureDoesNotMatch) 발생
+                    - 로그인한 사용자와 place의 owner가 일치해야 함
+                    """,
+            security = @SecurityRequirement(name = "bearerAuth"),
+            responses = {
+                    @ApiResponse(
+                            responseCode = "200",
+                            description = "presigned URL 발급 성공",
+                            content = @Content(mediaType = "application/json",
+                                    schema = @Schema(implementation = PresignResponse.class))
+                    ),
+                    @ApiResponse(responseCode = "403", description = "권한 없음"),
+                    @ApiResponse(responseCode = "400", description = "잘못된 요청"),
+                    @ApiResponse(responseCode = "500", description = "서명 생성 실패")
+            }
+    )
+    @PostMapping("/presign")
+    public ResponseEntity<CommonResponse<PresignResponse>> createPlaceImagePresign(
+            @RequestBody @Valid PlaceImagePresignRequest request,
+            @AuthenticationPrincipal CustomUserDetails user
+    ) {
+
+        PresignResponse response = profileImageService.createPlaceImagePresign(
+                request.placeId(),
+                user.getId(),
+                request.fileExtension(),
+                request.contentType()
+        );
+
+        return ResponseUtil.success(response);
+    }
+}

--- a/src/main/java/shympyo/rental/dto/PlaceImagePresignRequest.java
+++ b/src/main/java/shympyo/rental/dto/PlaceImagePresignRequest.java
@@ -1,0 +1,9 @@
+package shympyo.rental.dto;
+
+public record PlaceImagePresignRequest(
+        Long placeId,
+        String fileExtension,
+        String contentType
+) {
+}
+

--- a/src/main/java/shympyo/rental/service/PlaceService.java
+++ b/src/main/java/shympyo/rental/service/PlaceService.java
@@ -6,18 +6,14 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import shympyo.rental.domain.Place;
 import shympyo.rental.domain.PlaceStatus;
-import shympyo.report.dto.ProviderBlockUserRequest;
 import shympyo.rental.dto.PlaceCreateRequest;
 import shympyo.rental.dto.PlaceResponse;
 import shympyo.rental.dto.PlaceUpdateRequest;
 import shympyo.rental.repository.PlaceRepository;
-import shympyo.report.domain.SanctionSource;
-import shympyo.report.service.SanctionService;
 import shympyo.user.domain.User;
 import shympyo.user.domain.UserRole;
 import shympyo.user.repository.UserRepository;
 
-import java.time.LocalDateTime;
 import java.util.UUID;
 
 @Service
@@ -28,7 +24,6 @@ public class PlaceService {
 
     private final UserRepository userRepository;
     private final PlaceRepository placeRepository;
-    private final SanctionService sanctionService;
 
     @Transactional
     public PlaceResponse createPlace(Long userId, PlaceCreateRequest request) {

--- a/src/main/java/shympyo/storage/dto/PresignResponse.java
+++ b/src/main/java/shympyo/storage/dto/PresignResponse.java
@@ -1,4 +1,4 @@
-package shympyo.user.dto;
+package shympyo.storage.dto;
 
 public record PresignResponse(
         String uploadUrl,

--- a/src/main/java/shympyo/storage/service/ImagePresignService.java
+++ b/src/main/java/shympyo/storage/service/ImagePresignService.java
@@ -1,17 +1,19 @@
-package shympyo.user.service;
+package shympyo.storage.service;
 
 import java.time.Duration;
+import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
-import shympyo.user.dto.PresignRequest;
-import shympyo.user.dto.PresignResponse;
+import shympyo.rental.repository.PlaceRepository;
+import shympyo.storage.dto.PresignResponse;
 import software.amazon.awssdk.services.s3.model.PutObjectRequest;
 import software.amazon.awssdk.services.s3.presigner.S3Presigner;
 import software.amazon.awssdk.services.s3.presigner.model.PresignedPutObjectRequest;
 import software.amazon.awssdk.services.s3.presigner.model.PutObjectPresignRequest;
 
 @Service
-public class ProfileImageService {
+@RequiredArgsConstructor
+public class ImagePresignService {
 
     @Value("${ncp.object-storage.bucket}")
     private String bucket;
@@ -20,18 +22,35 @@ public class ProfileImageService {
     private String publicBaseUrl;
 
     private final S3Presigner presigner;
+    private final PlaceRepository placeRepository;
 
-    public ProfileImageService(S3Presigner presigner) {
-        this.presigner = presigner;
-    }
 
-    public PresignResponse createPresignedUpload(Long userId, String fileExtension, String contentType) {
+    public PresignResponse createUserProfilePresign(Long userId, String fileExtension, String contentType) {
+
 
         String objectKey = "users/%d/profile_%d.%s".formatted(
                 userId,
                 System.currentTimeMillis(),
                 fileExtension
         );
+        return createPresignForKey(objectKey, contentType);
+    }
+
+    public PresignResponse createPlaceImagePresign(Long placeId, Long userId, String fileExtension, String contentType) {
+
+        if (!placeRepository.existsByIdAndOwnerId(placeId, userId)) {
+            throw new IllegalArgumentException("해당 장소는 이 제공자의 소유가 아닙니다.");
+        }
+
+        String objectKey = "places/%d/main_%d.%s".formatted(
+                placeId,
+                System.currentTimeMillis(),
+                fileExtension
+        );
+        return createPresignForKey(objectKey, contentType);
+    }
+
+    private PresignResponse createPresignForKey(String objectKey, String contentType) {
 
         PutObjectRequest putObjectRequest = PutObjectRequest.builder()
                 .bucket(bucket)
@@ -48,11 +67,14 @@ public class ProfileImageService {
         PresignedPutObjectRequest presigned = presigner.presignPutObject(presignRequest);
 
         String uploadUrl = presigned.url().toString();
-        String publicUrl = "%s/%s/%s".formatted(publicBaseUrl, bucket, objectKey);
+        String publicUrl = "%s/%s/%s".formatted(
+                publicBaseUrl,
+                bucket,
+                objectKey
+        );
 
         return new PresignResponse(uploadUrl, objectKey, publicUrl);
     }
-
 
     private String buildObjectKey(String userId, String fileExtension) {
         long now = System.currentTimeMillis();

--- a/src/main/java/shympyo/user/controller/ProfileImageController.java
+++ b/src/main/java/shympyo/user/controller/ProfileImageController.java
@@ -17,16 +17,16 @@ import org.springframework.web.bind.annotation.RestController;
 import shympyo.auth.user.CustomUserDetails;
 import shympyo.global.response.CommonResponse;
 import shympyo.global.response.ResponseUtil;
-import shympyo.user.dto.PresignRequest;
-import shympyo.user.dto.PresignResponse;
-import shympyo.user.service.ProfileImageService;
+import shympyo.storage.dto.PresignResponse;
+import shympyo.user.dto.UserImagePresignRequest;
+import shympyo.storage.service.ImagePresignService;
 
 @RestController
 @RequestMapping("/api/profile-image")
 @RequiredArgsConstructor
 public class ProfileImageController {
 
-    private final ProfileImageService profileImageService;
+    private final ImagePresignService profileImageService;
 
     @Operation(
             summary = "프로필 이미지 업로드용 presigned URL 발급",
@@ -82,12 +82,12 @@ public class ProfileImageController {
     )
     @PostMapping("/presign")
     public ResponseEntity<CommonResponse<PresignResponse>> createPresignedUrl(
-            @RequestBody @Valid PresignRequest request,
+            @RequestBody @Valid UserImagePresignRequest request,
             @Parameter(hidden = true)
             @AuthenticationPrincipal CustomUserDetails user
     ) {
 
-        PresignResponse response = profileImageService.createPresignedUpload(
+        PresignResponse response = profileImageService.createUserProfilePresign(
                 user.getId(),
                 request.fileExtension(),
                 request.contentType()

--- a/src/main/java/shympyo/user/dto/UserImagePresignRequest.java
+++ b/src/main/java/shympyo/user/dto/UserImagePresignRequest.java
@@ -2,7 +2,7 @@ package shympyo.user.dto;
 
 import jakarta.validation.constraints.NotBlank;
 
-public record PresignRequest(
+public record UserImagePresignRequest(
         @NotBlank String fileExtension,
         @NotBlank String contentType
 ) {


### PR DESCRIPTION
## ✅ PR 내용

### ✨ 어떤 작업을 했나요?
> 작업한 내용을 간단히 요약해주세요.

### **요청 흐름**
1. 이 API 호출 → uploadUrl, publicUrl, objectKey 반환
2. 클라이언트가 uploadUrl로 PUT 업로드
3. 업로드 완료 후 publicUrl을 place 수정 API로 전달하여 저장
       
### **주의사항**
- 업로드 시 헤더:
  - Content-Type: 요청 시 전달한 값과 동일 (예: image/jpeg)
  - x-amz-acl: public-read
- 헤더 불일치 시 403(SignatureDoesNotMatch) 발생
- 로그인한 사용자와 place의 owner가 일치해야 함             
---

### 🔗 관련 이슈
> 이 PR이 병합되면 자동으로 닫힐 이슈 번호를 적어주세요.  
> `closes #이슈번호`, `fixes #이슈번호`, `resolves #이슈번호` 형식으로 작성해야 자동 닫기가 됩니다.

예시: `closes #12`

---

### 🧪 테스트 방법
> PR을 테스트한 방법이나 확인 결과를 적어주세요.

- [ ] 직접 테스트 완료
- [ ] Postman / Swagger로 API 확인
- [ ] 테스트 코드 통과

---

### 💬 기타 공유할 내용
> 리뷰어에게 공유할 내용이나 참고해야 할 사항이 있다면 자유롭게 작성해주세요.

-
